### PR TITLE
Entitlements view

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_SQUARELET_API_URL="https://server.presspass.dev/pp-api"
+REACT_APP_SQUARELET_API_URL="http://dev.presspass.com/pp-api"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import { State, AppProps } from "./store";
 import * as authActions from "./store/auth/actions";
 import * as clientActions from "./store/clients/actions";
+import * as entitlementActions from "./store/entitlements/actions";
 import * as userActions from "./store/users/actions";
 import { AuthProps } from "./store/auth/types";
 import { forceCheckAuth } from "./store/auth/api";
@@ -74,13 +75,14 @@ const App = (props: AppProps) => {
 const mapStateToProps = (state: State) => ({
   auth: state.auth,
   clients: state.clients,
+  entitlements: state.entitlements,
   users: state.users,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
   // TODO: assign type explicitly
   actions: bindActionCreators(
-    Object.assign({}, authActions, clientActions, userActions),
+    Object.assign({}, authActions, clientActions, entitlementActions, userActions),
     dispatch
   )
 });

--- a/src/entitlements/EntitlementCard.tsx
+++ b/src/entitlements/EntitlementCard.tsx
@@ -19,12 +19,9 @@ const EntitlementCard: React.FC<EntitlementCardProps> = (props: EntitlementCardP
           </div>
         </div>
 
-        <div className="control">
-          <div className="tags has-addons">
-            <span className="tag is-dark">Description</span>
-            <span className="tag is-primary">{entitlement.description}</span>
-          </div>
-        </div>
+      </div>
+      <div className="content">
+        <p>{entitlement.description}</p>
       </div>
     </Link>
   );

--- a/src/entitlements/EntitlementCard.tsx
+++ b/src/entitlements/EntitlementCard.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Entitlement } from "../store/entitlements/types";
+import { Link } from "react-router-dom";
+
+interface EntitlementCardProps {
+  entitlement: Entitlement;
+}
+
+const EntitlementCard: React.FC<EntitlementCardProps> = (props: EntitlementCardProps) => {
+  let entitlement = props.entitlement;
+  return (
+    <Link className="box" to={"/entitlements/" + entitlement.id}>
+      <h5 className="title is-size-5">{entitlement.name}</h5>
+      <div className="field is-grouped is-grouped-multiline">
+        <div className="control">
+          <div className="tags has-addons">
+            <span className="tag is-dark">Name</span>
+            <span className="tag is-info">{entitlement.name}</span>
+          </div>
+        </div>
+
+        <div className="control">
+          <div className="tags has-addons">
+            <span className="tag is-dark">Description</span>
+            <span className="tag is-primary">{entitlement.description}</span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default EntitlementCard;

--- a/src/entitlements/EntitlementsList.tsx
+++ b/src/entitlements/EntitlementsList.tsx
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, { useEffect } from "react";
 import { AppActions } from '../store';
+import { ensureEntitlements } from "../store/entitlements/api";
+import EntitlementCard from "./EntitlementCard";
+import { EntitlementState, Entitlement } from "../store/entitlements/types";
 
 interface EntitlementsListProps {
   actions: AppActions;
+  entitlements: EntitlementState;
 }
 
-const EntitlementsList: React.FC<EntitlementsListProps> = (
-  props: EntitlementsListProps
-) => {
+const EntitlementsList: React.FC<EntitlementsListProps> = (props: EntitlementsListProps) => {
+  useEffect(() => {
+    ensureEntitlements(props.actions, props.entitlements);
+  }, [props.actions, props.entitlements]);
+
   return (
-    <p>Entitlements List</p>
+    <div className="entitlements">
+    <h1 className="title is-size-1">Entitlements</h1>
+    <div className="columns is-multiline">
+    {Object.values(props.entitlements.entitlements).map((entitlement: Entitlement) => (
+      <div className="column is-4">
+        <EntitlementCard entitlement={entitlement} />
+      </div>
+    ))}
+    </div>
+    </div>
   )
 }
 

--- a/src/entitlements/routing.tsx
+++ b/src/entitlements/routing.tsx
@@ -8,7 +8,7 @@ export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
   const routes = [
     <ProtectedRoute exact path="/entitlements" {...authProps}>
-      <EntitlementsList actions={props.actions} />
+      <EntitlementsList actions={props.actions} entitlements={props.entitlements} />
     </ProtectedRoute>
   ];
   return routes;

--- a/src/store/entitlements/actions.ts
+++ b/src/store/entitlements/actions.ts
@@ -1,0 +1,40 @@
+import {
+  UPSERT_ENTITLEMENT,
+  Entitlement,
+  UPSERT_ENTITLEMENTS,
+  DELETE_ENTITLEMENT,
+  DeleteEntitlementAction,
+  UpsertEntitlementAction,
+  UpsertEntitlementsAction
+} from "./types";
+
+export function upsertEntitlement(entitlement: Entitlement): UpsertEntitlementAction {
+  return {
+    type: UPSERT_ENTITLEMENT,
+    entitlement: entitlement
+  };
+}
+
+// This action is necessary because if one wants to
+// upsert multiple entitlements into the store at load time,
+// calling each `upsertEntitlement` individually would cause
+// the 'hydrated' field to be set to `true` after the first
+// upsert (but before all the data has been loaded). This
+// can cause issues when there are multiple entitlements,
+// as a view might be waiting for `hydrated` to be `true`
+// before displaying data from a particular entitlement. If
+// `hydrated` is set to `true` too early, this can cause
+// these views to fail.
+export function upsertEntitlements(entitlements: Entitlement[]): UpsertEntitlementsAction {
+  return {
+    type: UPSERT_ENTITLEMENTS,
+    entitlements: entitlements
+  };
+}
+
+export function deleteEntitlement(entitlement: Entitlement): DeleteEntitlementAction {
+  return {
+    type: DELETE_ENTITLEMENT,
+    entitlement: entitlement
+  };
+}

--- a/src/store/entitlements/api.ts
+++ b/src/store/entitlements/api.ts
@@ -1,0 +1,91 @@
+import { AppActions } from "..";
+import {
+  checkAuth,
+  cfetch,
+  validate,
+  ItemizedResponse,
+  notify,
+  GET,
+  PATCH,
+  POST,
+  DELETE
+} from "../../utils";
+import { Entitlement, EntitlementState } from "./types";
+
+const serializeEntitlement = (entitlement: Entitlement) => ({
+  id: entitlement.id,
+  name: entitlement.name || "",
+  description: entitlement.description || "",
+  // Explicitly setting each field is necessary here, because
+  // not all of the fields in entitlement are write-available, and
+  // including them in the request would result in a 400 response.
+});
+
+export const fetchEntitlements = (actions: AppActions) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/`, GET)
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertEntitlements(data.results)]))
+    .catch(error => {
+      console.error("API Error fetchEntitlements", error, error.code);
+    });
+
+export const ensureEntitlements = (actions: AppActions, entitlements: EntitlementState) => {
+  if (!entitlements.hydrated) {
+    return fetchEntitlements(actions);
+  }
+};
+
+export const updateEntitlement = (entitlement: Entitlement, actions: AppActions) => {
+  let formData = new FormData();
+  let packagedEntitlement: any = serializeEntitlement(entitlement);
+  for (let key of Object.keys(packagedEntitlement)) {
+    formData.append(key, packagedEntitlement[key]);
+  }
+  return cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/${entitlement.id}/`,
+    PATCH(formData)
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertEntitlement(status.body as Entitlement);
+        notify(`Successfully updated ${entitlement.name}.`, "success");
+      })
+    );
+};
+
+export const createEntitlement = (entitlement: Entitlement, actions: AppActions) => {
+  let formData = new FormData();
+  let packagedEntitlement: any = serializeEntitlement(entitlement);
+  for (let key of Object.keys(packagedEntitlement)) {
+    formData.append(key, packagedEntitlement[key]);
+  }
+  return (
+    cfetch(
+      `${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/`,
+      POST(formData)
+    )
+      .then(checkAuth(actions))
+      // Cannot call upsert entitlement here, because IDs are assigned on the server side
+      .then(response =>
+        validate(response, (status: ItemizedResponse) => {
+          actions.upsertEntitlement(status.body as Entitlement);
+          notify(`Successfully created ${entitlement.name}.`, "success");
+        })
+      )
+  );
+};
+
+export const deleteEntitlement = (entitlement: Entitlement, actions: AppActions) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/${entitlement.id}`,
+    DELETE
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, () => {
+        actions.deleteEntitlement(entitlement);
+        notify(`Successfully deleted ${entitlement.name}.`, "success");
+      })
+    );

--- a/src/store/entitlements/reducers.ts
+++ b/src/store/entitlements/reducers.ts
@@ -1,0 +1,48 @@
+import {
+  EntitlementAction,
+  UPSERT_ENTITLEMENT,
+  EntitlementState,
+  UPSERT_ENTITLEMENTS,
+  DELETE_ENTITLEMENT
+} from "./types";
+
+const initialState: EntitlementState = {
+  entitlements: {},
+  hydrated: false
+};
+
+export function entitlementReducers(
+  state = initialState,
+  action: EntitlementAction
+): EntitlementState {
+  switch (action.type) {
+    case UPSERT_ENTITLEMENTS: {
+      let incomingObject: EntitlementState = {
+        entitlements: Object.assign({}, state.entitlements),
+        hydrated: true
+      };
+      for (let entitlement of action.entitlements) {
+        incomingObject.entitlements[entitlement.id] = entitlement;
+      }
+      return Object.assign({}, state, incomingObject);
+    }
+    case UPSERT_ENTITLEMENT: {
+      let incomingObject: EntitlementState = {
+        entitlements: Object.assign({}, state.entitlements),
+        hydrated: true
+      };
+      incomingObject.entitlements[action.entitlement.id] = action.entitlement;
+      return Object.assign({}, state, incomingObject);
+    }
+    case DELETE_ENTITLEMENT: {
+      let incomingObject: EntitlementState = {
+        entitlements: Object.assign({}, state.entitlements),
+        hydrated: true
+      };
+      delete incomingObject.entitlements[action.entitlement.id];
+      return Object.assign({}, state, incomingObject);
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/entitlements/types.ts
+++ b/src/store/entitlements/types.ts
@@ -1,0 +1,34 @@
+export const UPSERT_ENTITLEMENT = "UPSERT_ENTITLEMENT";
+export const UPSERT_ENTITLEMENTS = "UPSERT_ENTITLEMENTS";
+export const DELETE_ENTITLEMENT = "DELETE_ENTITLEMENT";
+
+export interface Entitlement {
+  id: number;
+  name: string;
+  description: string;
+}
+
+export interface EntitlementState {
+  entitlements: { [id: number]: Entitlement };
+  hydrated: boolean;
+}
+
+export interface UpsertEntitlementAction {
+  type: typeof UPSERT_ENTITLEMENT;
+  entitlement: Entitlement;
+}
+
+export interface UpsertEntitlementsAction {
+  type: typeof UPSERT_ENTITLEMENTS;
+  entitlements: Entitlement[];
+}
+
+export interface DeleteEntitlementAction {
+  type: typeof DELETE_ENTITLEMENT;
+  entitlement: Entitlement;
+}
+
+export type EntitlementAction =
+  | UpsertEntitlementAction
+  | UpsertEntitlementsAction
+  | DeleteEntitlementAction;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,11 @@ import { upsertClient, upsertClients, deleteClient } from "./clients/actions";
 import { clientReducers } from "./clients/reducers";
 import { ClientState } from "./clients/types";
 
+// Entitlements
+import { upsertEntitlement, upsertEntitlements, deleteEntitlement } from "./entitlements/actions";
+import { entitlementReducers } from "./entitlements/reducers";
+import { EntitlementState } from "./entitlements/types";
+
 // Users
 import { upsertSelfUser } from "./users/actions";
 import { usersReducers } from "./users/reducers";
@@ -23,6 +28,7 @@ import { UsersState } from "./users/types";
 const reducers = combineReducers({
   auth: authReducers,
   clients: clientReducers,
+  entitlements: entitlementReducers,
   users: usersReducers
 });
 
@@ -41,6 +47,9 @@ export interface AppActions {
   upsertClient: typeof upsertClient;
   upsertClients: typeof upsertClients;
   deleteClient: typeof deleteClient;
+  upsertEntitlement: typeof upsertEntitlement;
+  upsertEntitlements: typeof upsertEntitlements;
+  deleteEntitlement: typeof deleteEntitlement;
   upsertSelfUser: typeof upsertSelfUser;
 }
 
@@ -48,6 +57,7 @@ export interface AppProps {
   auth: AuthState;
   actions: AppActions;
   clients: ClientState;
+  entitlements: EntitlementState;
   users: UsersState;
 }
 


### PR DESCRIPTION
I've added the scaffolding required to display a list of entitlements: routing, store, and views. I should note a couple things:

1. I haven't successfully _created_ an entitlement so, for now, my list is... empty locally
2. I took a look at the properties on entitlements in the swagger docs and went with merely `name` and `description` for a start
3. Not 100% sure if or how much I need to take the `client` relationship (?) into account here

But... it's a start :)

Locally, I added the scaffold to create a new entitlement but I haven't included this code here - don't know if it's warranted. 

~I ran into an issue with the API domain that I'll try to sort out before I quit working today as well - something must have server.presspass.dev hardcoded that I missed.~ _found it in .env_