### PR TITLE
Updates to the profile page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import * as authActions from './store/auth/actions';
 import * as clientActions from './store/clients/actions';
 import * as entitlementActions from './store/entitlements/actions';
 import * as organizationActions from './store/organizations/actions';
+import * as invitationActions from './store/invitations/actions';
 import * as membershipActions from './store/memberships/actions';
 import * as userActions from './store/users/actions';
 import { AuthProps } from './store/auth/types';
@@ -82,6 +83,7 @@ const mapStateToProps = (state: State) => ({
   clients: state.clients,
   entitlements: state.entitlements,
   memberships: state.memberships,
+  invitations: state.invitations,
   organizations: state.organizations,
   users: state.users
 });
@@ -95,6 +97,7 @@ const mapDispatchToProps = (dispatch: any) => ({
       clientActions,
       entitlementActions,
       membershipActions,
+      invitationActions,
       organizationActions,
       userActions
     ),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,39 @@
 // React/redux
-import React, { useEffect } from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import {
   BrowserRouter as Router,
   Switch,
   Redirect,
   Route
-} from "react-router-dom";
+} from 'react-router-dom';
 
 // Local Redux store
-import { State, AppProps } from "./store";
-import * as authActions from "./store/auth/actions";
-import * as clientActions from "./store/clients/actions";
-import * as entitlementActions from "./store/entitlements/actions";
-import * as organizationActions from "./store/organizations/actions";
-import * as userActions from "./store/users/actions";
-import { AuthProps } from "./store/auth/types";
-import { forceCheckAuth } from "./store/auth/api";
-import { fetchSelfUser } from "./store/users/api";
+import { State, AppProps } from './store';
+import * as authActions from './store/auth/actions';
+import * as clientActions from './store/clients/actions';
+import * as entitlementActions from './store/entitlements/actions';
+import * as organizationActions from './store/organizations/actions';
+import * as userActions from './store/users/actions';
+import { AuthProps } from './store/auth/types';
+import { forceCheckAuth } from './store/auth/api';
+import { fetchSelfUser } from './store/users/api';
 
 // Common
-import Navbar from "./common/Navbar";
-import { ProtectedRoute } from "./common/routing";
-import NotFound from "./common/NotFound";
+import Navbar from './common/Navbar';
+import { ProtectedRoute } from './common/routing';
+import NotFound from './common/NotFound';
 
 // Routes
-import { getRoutes as authRoutes } from "./auth/routing";
-import { getRoutes as clientsRoutes } from "./clients/routing";
-import { getRoutes as accountRoutes } from "./account/routing";
-import { getRoutes as entitlementsRoutes } from "./entitlements/routing";
-import { getRoutes as organizationsRoutes } from "./organization/routing";
+import { getRoutes as authRoutes } from './auth/routing';
+import { getRoutes as clientsRoutes } from './clients/routing';
+import { getRoutes as accountRoutes } from './account/routing';
+import { getRoutes as entitlementsRoutes } from './entitlements/routing';
+import { getRoutes as organizationsRoutes } from './organization/routing';
 
 // Styles
-import "./App.css";
-
+import './App.css';
 
 const App = (props: AppProps) => {
   useEffect(() => {
@@ -47,7 +46,11 @@ const App = (props: AppProps) => {
   return (
     <Router>
       <div>
-        <Navbar {...authProps} actions={props.actions} user={props.users.self} />
+        <Navbar
+          {...authProps}
+          actions={props.actions}
+          user={props.users.self}
+        />
         <section className="section">
           <div className="container">
             <Switch>
@@ -78,13 +81,20 @@ const mapStateToProps = (state: State) => ({
   clients: state.clients,
   entitlements: state.entitlements,
   organizations: state.organizations,
-  users: state.users,
+  users: state.users
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
   // TODO: assign type explicitly
   actions: bindActionCreators(
-    Object.assign({}, authActions, clientActions, entitlementActions, userActions),
+    Object.assign(
+      {},
+      authActions,
+      clientActions,
+      entitlementActions,
+      organizationActions,
+      userActions
+    ),
     dispatch
   )
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import * as authActions from './store/auth/actions';
 import * as clientActions from './store/clients/actions';
 import * as entitlementActions from './store/entitlements/actions';
 import * as organizationActions from './store/organizations/actions';
+import * as membershipActions from './store/memberships/actions';
 import * as userActions from './store/users/actions';
 import { AuthProps } from './store/auth/types';
 import { forceCheckAuth } from './store/auth/api';
@@ -80,6 +81,7 @@ const mapStateToProps = (state: State) => ({
   auth: state.auth,
   clients: state.clients,
   entitlements: state.entitlements,
+  memberships: state.memberships,
   organizations: state.organizations,
   users: state.users
 });
@@ -92,6 +94,7 @@ const mapDispatchToProps = (dispatch: any) => ({
       authActions,
       clientActions,
       entitlementActions,
+      membershipActions,
       organizationActions,
       userActions
     ),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { State, AppProps } from "./store";
 import * as authActions from "./store/auth/actions";
 import * as clientActions from "./store/clients/actions";
 import * as entitlementActions from "./store/entitlements/actions";
+import * as organizationActions from "./store/organizations/actions";
 import * as userActions from "./store/users/actions";
 import { AuthProps } from "./store/auth/types";
 import { forceCheckAuth } from "./store/auth/api";
@@ -76,6 +77,7 @@ const mapStateToProps = (state: State) => ({
   auth: state.auth,
   clients: state.clients,
   entitlements: state.entitlements,
+  organizations: state.organizations,
   users: state.users,
 });
 

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -1,51 +1,97 @@
-import React from 'react';
-import { AppProps } from '../store';
+import React, { useEffect } from 'react';
+import { AppProps, AppActions } from '../store';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
+import { Organization, OrganizationState } from '../store/organizations/types';
+import { fetchOrganizationsForUser } from '../store/organizations/api';
+import OrganizationCard from '../organization/OrganizationCard';
+import { UsersState } from '../store/users/types';
 
-export const ProfilePage: React.FC<AppProps> = (props: AppProps) => {
-    if (props.users.self == null) {
-        return (<LoadingPlaceholder/>);
-    }
-    return (
-        <article className="media profile">
-            <figure className="media-left">
-                <p className="image is-64x64">
-                    <img src={props.users.self.avatar}/>
-                </p>
-            </figure>
-            <div className="media-content">
-                <div className="content">
-                    <h1 className="title is-size-1">Your Profile</h1>
-                    <table className="table">
-                        <tbody>
-                            <tr>
-                                <th>Name:</th>
-                                <td>{props.users.self.name}</td>
-                            </tr>
-                            <tr>
-                                <th>Username:</th>
-                                <td>{props.users.self.username}</td>
-                            </tr>
-                            <tr>
-                                <th>Email:</th>
-                                <td>{props.users.self.email}</td>
-                            </tr>
-                            <tr>
-                                <th>Password:</th>
-                                <td>
-                                    <Link to="/profile/change-password" className="is-link is-outlined">
-                                        Change Password
-                                    </Link>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <Link to="/clients" className="button is-link is-outlined">
-                        Manage Clients
-                    </Link>
-                </div>
-            </div>
-        </article>
-    )
+interface ProfilePageProps {
+  actions: AppActions;
+  users: UsersState;
+  organizations: OrganizationState;
 }
+
+export const ProfilePage: React.FC<ProfilePageProps> = (
+  props: ProfilePageProps
+) => {
+  if (props.users.self == null) {
+    return <LoadingPlaceholder />;
+  } else {
+    return <HydratedProfile {...props} />;
+  }
+};
+
+export const HydratedProfile: React.FC<ProfilePageProps> = (
+  props: ProfilePageProps
+) => {
+  let name = props.users.self!.name;
+  let username = props.users.self!.username;
+  let email = props.users.self!.email;
+  let uuid = props.users.self!.uuid;
+  let avatar = props.users.self!.avatar;
+
+  useEffect(() => {
+    fetchOrganizationsForUser(props.actions, uuid);
+  }, [props.actions, props.organizations]);
+
+  console.log(props.organizations);
+  let membershipInfo = props.organizations.hydrated ? (
+    <div className="memberships">
+      <h1 className="title is-size-2">Memberships</h1>
+      <div>
+        TK TK Your organizations will be listed here once I figure out the
+        syntax of things.
+      </div>
+    </div>
+  ) : null;
+
+  return (
+    <article className="media profile">
+      <figure className="media-left">
+        <p className="image is-64x64">
+          <img src={avatar} />
+        </p>
+      </figure>
+      <div className="media-content">
+        <div className="content">
+          <h1 className="title is-size-1">Your Profile</h1>
+          <table className="table">
+            <tbody>
+              <tr>
+                <th>Name:</th>
+                <td>{name}</td>
+              </tr>
+              <tr>
+                <th>Username:</th>
+                <td>{username}</td>
+              </tr>
+              <tr>
+                <th>Email:</th>
+                <td>{email}</td>
+              </tr>
+              <tr>
+                <th>Password:</th>
+                <td>
+                  <Link
+                    to="/profile/change-password"
+                    className="is-link is-outlined"
+                  >
+                    Change Password
+                  </Link>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          {membershipInfo}
+
+          <Link to="/clients" className="button is-link is-outlined">
+            Manage Clients
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -2,8 +2,10 @@ import React, { useEffect } from 'react';
 import { AppActions } from '../store';
 import { Link } from 'react-router-dom';
 import { Membership, MembershipState } from '../store/memberships/types';
+import { Invitation, InvitationState } from '../store/invitations/types';
 import { ensureMembershipsForUser } from '../store/memberships/api';
 import MembershipCard from '../membership/MembershipCard';
+import InvitationList from '../invitation/InvitationList';
 import { UsersState } from '../store/users/types';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 
@@ -11,6 +13,7 @@ interface ProfilePageProps {
   actions: AppActions;
   users: UsersState;
   memberships: MembershipState;
+  invitations: InvitationState;
 }
 
 export const ProfilePage: React.FC<ProfilePageProps> = (
@@ -30,7 +33,6 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
     let name = props.users.self!.name;
     let username = props.users.self!.username;
     let email = props.users.self!.email;
-    // let uuid = props.users.self!.uuid;
     let avatar = props.users.self!.avatar;
 
     return (
@@ -81,6 +83,12 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
                 )
               )}
             </div>
+
+            <InvitationList
+              actions={props.actions}
+              uuid={props.users.self!.uuid}
+              invitations={props.invitations}
+            />
           </div>
         </div>
       </article>

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -1,16 +1,51 @@
 import React from 'react';
 import { AppProps } from '../store';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { Link } from "react-router-dom";
 
 export const ProfilePage: React.FC<AppProps> = (props: AppProps) => {
     if (props.users.self == null) {
         return (<LoadingPlaceholder/>);
     }
     return (
-        <div className="profile">
-
-            <p>Name: {props.users.self.name}</p>
-            <p>Username: {props.users.self.username}</p>
-        </div>
+        <article className="media profile">
+            <figure className="media-left">
+                <p className="image is-64x64">
+                    <img src={props.users.self.avatar}/>
+                </p>
+            </figure>
+            <div className="media-content">
+                <div className="content">
+                    <h1 className="title is-size-1">Your Profile</h1>
+                    <table className="table">
+                        <tbody>
+                            <tr>
+                                <th>Name:</th>
+                                <td>{props.users.self.name}</td>
+                            </tr>
+                            <tr>
+                                <th>Username:</th>
+                                <td>{props.users.self.username}</td>
+                            </tr>
+                            <tr>
+                                <th>Email:</th>
+                                <td>{props.users.self.email}</td>
+                            </tr>
+                            <tr>
+                                <th>Password:</th>
+                                <td>
+                                    <Link to="/profile/change-password" className="is-link is-outlined">
+                                        Change Password
+                                    </Link>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <Link to="/clients" className="button is-link is-outlined">
+                        Manage Clients
+                    </Link>
+                </div>
+            </div>
+        </article>
     )
 }

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -70,6 +70,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
               </tbody>
             </table>
 
+            <h1 className="title is-size-3">Your Memberships</h1>
             <div className="columns is-multiline">
               {Object.values(props.organizations.organizations).map(
                 (organization: Organization) => (

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
-import { AppProps, AppActions } from '../store';
-import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { AppActions } from '../store';
 import { Link } from 'react-router-dom';
 import { Organization, OrganizationState } from '../store/organizations/types';
-import { fetchOrganizationsForUser } from '../store/organizations/api';
+import { ensureOrganizationsForUser } from '../store/organizations/api';
 import OrganizationCard from '../organization/OrganizationCard';
 import { UsersState } from '../store/users/types';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
 
 interface ProfilePageProps {
   actions: AppActions;
@@ -16,82 +16,72 @@ interface ProfilePageProps {
 export const ProfilePage: React.FC<ProfilePageProps> = (
   props: ProfilePageProps
 ) => {
+  useEffect(() => {
+    if (props.users.self !== null) {
+      const uuid = props.users.self.uuid;
+      ensureOrganizationsForUser(props.actions, uuid, props.organizations);
+    }
+  }, [props.actions, props.organizations, props.users, props.users.self]);
+
   if (props.users.self == null) {
     return <LoadingPlaceholder />;
   } else {
-    return <HydratedProfile {...props} />;
-  }
-};
+    let name = props.users.self!.name;
+    let username = props.users.self!.username;
+    let email = props.users.self!.email;
+    let uuid = props.users.self!.uuid;
+    let avatar = props.users.self!.avatar;
 
-export const HydratedProfile: React.FC<ProfilePageProps> = (
-  props: ProfilePageProps
-) => {
-  let name = props.users.self!.name;
-  let username = props.users.self!.username;
-  let email = props.users.self!.email;
-  let uuid = props.users.self!.uuid;
-  let avatar = props.users.self!.avatar;
+    return (
+      <article className="media profile">
+        <figure className="media-left">
+          <p className="image is-64x64">
+            <img src={avatar} />
+          </p>
+        </figure>
+        <div className="media-content">
+          <div className="content">
+            <h1 className="title is-size-1">Your Profile</h1>
+            <table className="table">
+              <tbody>
+                <tr>
+                  <th>Name:</th>
+                  <td>{name}</td>
+                </tr>
+                <tr>
+                  <th>Username:</th>
+                  <td>{username}</td>
+                </tr>
+                <tr>
+                  <th>Email:</th>
+                  <td>{email}</td>
+                </tr>
+                <tr>
+                  <th>Password:</th>
+                  <td>
+                    <Link
+                      to="/profile/change-password"
+                      className="is-link is-outlined"
+                    >
+                      Change Password
+                    </Link>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
 
-  useEffect(() => {
-    fetchOrganizationsForUser(props.actions, uuid);
-  }, [props.actions, props.organizations]);
-
-  console.log(props.organizations);
-  let membershipInfo = props.organizations.hydrated ? (
-    <div className="memberships">
-      <h1 className="title is-size-2">Memberships</h1>
-      <div>
-        TK TK Your organizations will be listed here once I figure out the
-        syntax of things.
-      </div>
-    </div>
-  ) : null;
-
-  return (
-    <article className="media profile">
-      <figure className="media-left">
-        <p className="image is-64x64">
-          <img src={avatar} />
-        </p>
-      </figure>
-      <div className="media-content">
-        <div className="content">
-          <h1 className="title is-size-1">Your Profile</h1>
-          <table className="table">
-            <tbody>
-              <tr>
-                <th>Name:</th>
-                <td>{name}</td>
-              </tr>
-              <tr>
-                <th>Username:</th>
-                <td>{username}</td>
-              </tr>
-              <tr>
-                <th>Email:</th>
-                <td>{email}</td>
-              </tr>
-              <tr>
-                <th>Password:</th>
-                <td>
-                  <Link
-                    to="/profile/change-password"
-                    className="is-link is-outlined"
-                  >
-                    Change Password
-                  </Link>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-
-          {membershipInfo}
-
-          <Link to="/clients" className="button is-link is-outlined">
-            Manage Clients
-          </Link>
+            <div className="columns is-multiline">
+              {Object.values(props.organizations.organizations).map(
+                (organization: Organization) => (
+                  <div className="column is-4">
+                    <OrganizationCard organization={organization} />
+                  </div>
+                )
+              )}
+            </div>
+          </div>
         </div>
-      </div>
-    </article>
-  );
+      </article>
+    );
+  }
 };

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -1,27 +1,28 @@
 import React, { useEffect } from 'react';
 import { AppActions } from '../store';
 import { Link } from 'react-router-dom';
-import { Organization, OrganizationState } from '../store/organizations/types';
-import { ensureOrganizationsForUser } from '../store/organizations/api';
-import OrganizationCard from '../organization/OrganizationCard';
+import { Membership, MembershipState } from '../store/memberships/types';
+import { ensureMembershipsForUser } from '../store/memberships/api';
+import MembershipCard from '../membership/MembershipCard';
 import { UsersState } from '../store/users/types';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 
 interface ProfilePageProps {
   actions: AppActions;
   users: UsersState;
-  organizations: OrganizationState;
+  memberships: MembershipState;
 }
 
 export const ProfilePage: React.FC<ProfilePageProps> = (
   props: ProfilePageProps
 ) => {
+  // load user's memberships list
   useEffect(() => {
     if (props.users.self !== null) {
       const uuid = props.users.self.uuid;
-      ensureOrganizationsForUser(props.actions, uuid, props.organizations);
+      ensureMembershipsForUser(props.actions, uuid, props.memberships);
     }
-  }, [props.actions, props.organizations, props.users, props.users.self]);
+  }, [props.actions, props.memberships, props.users, props.users.self]);
 
   if (props.users.self == null) {
     return <LoadingPlaceholder />;
@@ -29,7 +30,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
     let name = props.users.self!.name;
     let username = props.users.self!.username;
     let email = props.users.self!.email;
-    let uuid = props.users.self!.uuid;
+    // let uuid = props.users.self!.uuid;
     let avatar = props.users.self!.avatar;
 
     return (
@@ -72,10 +73,10 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
 
             <h1 className="title is-size-3">Your Memberships</h1>
             <div className="columns is-multiline">
-              {Object.values(props.organizations.organizations).map(
-                (organization: Organization) => (
-                  <div className="column is-4">
-                    <OrganizationCard organization={organization} />
+              {Object.values(props.memberships.memberships).map(
+                (membership: Membership) => (
+                  <div key={membership.organization} className="column is-4">
+                    <MembershipCard membership={membership} />
                   </div>
                 )
               )}

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -1,18 +1,88 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { AppActions } from '../store';
 import { Invitation } from '../store/invitations/types';
+import { acceptInvitation, rejectInvitation } from '../store/invitations/api';
 import { Link } from 'react-router-dom';
 
 interface InvitationCardProps {
+  actions: AppActions;
   invitation: Invitation;
 }
 
-const InvitationCard: React.FC<InvitationCardProps> = (
+const InvitationActions: React.FC<InvitationCardProps> = (
   props: InvitationCardProps
 ) => {
+  let [saved, setSaved] = useState(false);
+  let [errors, setErrors] = useState({});
   let invitation = props.invitation;
-  return (
-    <Link className="box" to={'/organizations/' + invitation.organization}>
-      <h5 className="title is-size-5">{invitation.organization}</h5>
+
+  // i've been invited, and I can say yes or no
+  let showActionButtons =
+    props.invitation.accepted_at === null &&
+    props.invitation.rejected_at === null &&
+    !props.invitation.request;
+
+  // I've requested membership and it's pending
+  let showRequestIsPendingStatus =
+    props.invitation.accepted_at === null &&
+    props.invitation.rejected_at === null &&
+    props.invitation.request;
+
+  // I've requested membership and it's either been approved or booed
+  let showRequestIsHandledStatus =
+    (props.invitation.accepted_at !== null ||
+      props.invitation.rejected_at !== null) &&
+    props.invitation.request;
+
+  const onAcceptClick = () => {
+    invitation.accept = true; // pretty sure I'm not supposed to do that here
+    invitation.reject = false; // pretty sure I'm not supposed to do that here
+    console.log('accept', invitation);
+    acceptInvitation(invitation, props.actions).then(status => {
+      if (status.ok) {
+        console.log('successfully accepted the invite');
+        setSaved(true);
+      } else {
+        setErrors(status.body);
+      }
+    });
+  };
+
+  const onRejectClick = () => {
+    invitation.accept = false; // pretty sure I'm not supposed to do that here
+    invitation.reject = true; // pretty sure I'm not supposed to do that here
+    console.log('reject', invitation);
+    rejectInvitation(invitation, props.actions).then(status => {
+      if (status.ok) {
+        console.log('successfully rejected the invite');
+        setSaved(true);
+      } else {
+        setErrors(status.body);
+      }
+    });
+  };
+
+  if (showActionButtons) {
+    return (
+      <div className="buttons">
+        <button onClick={onAcceptClick} className="button is-success">
+          accept
+        </button>
+        <button onClick={onRejectClick} className="button is-danger">
+          reject
+        </button>
+      </div>
+    );
+  } else if (showRequestIsPendingStatus) {
+    return (
+      <div>
+        <p>
+          <strong>Your request is pending</strong>
+        </p>
+      </div>
+    );
+  } else if (showRequestIsHandledStatus) {
+    return (
       <div>
         {invitation.accepted_at !== null ? (
           <p>
@@ -20,7 +90,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
             <small>{invitation.accepted_at}</small>
           </p>
         ) : (
-          'include-accept-button'
+          ''
         )}
         {invitation.rejected_at !== null ? (
           <p>
@@ -28,13 +98,30 @@ const InvitationCard: React.FC<InvitationCardProps> = (
             <small>{invitation.rejected_at}</small>
           </p>
         ) : (
-          'include-reject-button'
+          ''
         )}
+      </div>
+    );
+  } else {
+    return <div>Unhandled invitation state.</div>;
+  }
+};
+
+const InvitationCard: React.FC<InvitationCardProps> = (
+  props: InvitationCardProps
+) => {
+  let invitation = props.invitation;
+
+  return (
+    <div key={invitation.uuid} className="box">
+      <h5 className="title is-size-5">{invitation.organization}</h5>
+      <div>
+        <InvitationActions actions={props.actions} invitation={invitation} />
         <p>
           <strong>Created at:</strong> <small>{invitation.created_at}</small>
         </p>
       </div>
-    </Link>
+    </div>
   );
 };
 

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -14,30 +14,26 @@ const InvitationActions: React.FC<InvitationCardProps> = (
 ) => {
   let [saved, setSaved] = useState(false);
   let [errors, setErrors] = useState({});
+  let accepted = !!props.invitation.accepted_at;
+  let rejected = !!props.invitation.rejected_at;
   let invitation = props.invitation;
 
   // i've been invited, and I can say yes or no
   let showActionButtons =
-    props.invitation.accepted_at === null &&
-    props.invitation.rejected_at === null &&
-    !props.invitation.request;
+    !accepted &&
+    !rejected &&
+    !invitation.request;
 
   // I've requested membership and it's pending
   let showRequestIsPendingStatus =
-    props.invitation.accepted_at === null &&
-    props.invitation.rejected_at === null &&
-    props.invitation.request;
+    !accepted &&
+    !rejected &&
+    invitation.request;
 
   // I've requested membership and it's either been approved or booed
-  let showRequestIsHandledStatus =
-    (props.invitation.accepted_at !== null ||
-      props.invitation.rejected_at !== null) &&
-    props.invitation.request;
+  let showInvitationIsHandledStatus = (accepted || rejected)
 
   const onAcceptClick = () => {
-    invitation.accept = true; // pretty sure I'm not supposed to do that here
-    invitation.reject = false; // pretty sure I'm not supposed to do that here
-    console.log('accept', invitation);
     acceptInvitation(invitation, props.actions).then(status => {
       if (status.ok) {
         console.log('successfully accepted the invite');
@@ -49,9 +45,6 @@ const InvitationActions: React.FC<InvitationCardProps> = (
   };
 
   const onRejectClick = () => {
-    invitation.accept = false; // pretty sure I'm not supposed to do that here
-    invitation.reject = true; // pretty sure I'm not supposed to do that here
-    console.log('reject', invitation);
     rejectInvitation(invitation, props.actions).then(status => {
       if (status.ok) {
         console.log('successfully rejected the invite');
@@ -81,10 +74,10 @@ const InvitationActions: React.FC<InvitationCardProps> = (
         </p>
       </div>
     );
-  } else if (showRequestIsHandledStatus) {
+  } else if (showInvitationIsHandledStatus) {
     return (
       <div>
-        {invitation.accepted_at !== null ? (
+        {accepted ? (
           <p>
             <strong>Accepted at:</strong>{' '}
             <small>{invitation.accepted_at}</small>
@@ -92,7 +85,7 @@ const InvitationActions: React.FC<InvitationCardProps> = (
         ) : (
           ''
         )}
-        {invitation.rejected_at !== null ? (
+        {rejected ? (
           <p>
             <strong>Rejected at:</strong>{' '}
             <small>{invitation.rejected_at}</small>

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Invitation } from '../store/invitations/types';
+import { Link } from 'react-router-dom';
+
+interface InvitationCardProps {
+  invitation: Invitation;
+}
+
+const InvitationCard: React.FC<InvitationCardProps> = (
+  props: InvitationCardProps
+) => {
+  let invitation = props.invitation;
+  return (
+    <Link className="box" to={'/organizations/' + invitation.organization}>
+      <h5 className="title is-size-5">{invitation.organization}</h5>
+      <div>
+        {invitation.accepted_at !== null ? (
+          <p>
+            <strong>Accepted at:</strong>{' '}
+            <small>{invitation.accepted_at}</small>
+          </p>
+        ) : (
+          'include-accept-button'
+        )}
+        {invitation.rejected_at !== null ? (
+          <p>
+            <strong>Rejected at:</strong>{' '}
+            <small>{invitation.rejected_at}</small>
+          </p>
+        ) : (
+          'include-reject-button'
+        )}
+        <p>
+          <strong>Created at:</strong> <small>{invitation.created_at}</small>
+        </p>
+      </div>
+    </Link>
+  );
+};
+
+export default InvitationCard;

--- a/src/invitation/InvitationList.tsx
+++ b/src/invitation/InvitationList.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { Invitation, InvitationState } from '../store/invitations/types';
+import InvitationCard from './InvitationCard';
+import { ensureInvitationsForUser } from '../store/invitations/api';
+
+interface InvitationListProps {
+  actions: AppActions;
+  invitations: InvitationState;
+  uuid: string;
+}
+
+const InvitationList: React.FC<InvitationListProps> = (
+  props: InvitationListProps
+) => {
+  useEffect(() => {
+    ensureInvitationsForUser(props.actions, props.uuid, props.invitations);
+  }, [props.actions, props.invitations]);
+
+  let invites = Object.values(props.invitations.invitations);
+  console.log('invitations: ', invites);
+  return (
+    <div>
+      <h1 className="title is-size-3">Your Invitations</h1>
+      <div className="columns is-multiline">
+        {Object.values(invites).map((invitation: Invitation) => (
+          <div key={invitation.organization} className="column is-4">
+            <InvitationCard invitation={invitation} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default InvitationList;

--- a/src/invitation/InvitationList.tsx
+++ b/src/invitation/InvitationList.tsx
@@ -25,7 +25,7 @@ const InvitationList: React.FC<InvitationListProps> = (
       <div className="columns is-multiline">
         {Object.values(invites).map((invitation: Invitation) => (
           <div key={invitation.organization} className="column is-4">
-            <InvitationCard invitation={invitation} />
+            <InvitationCard actions={props.actions} invitation={invitation} />
           </div>
         ))}
       </div>

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Membership } from '../store/memberships/types';
+import { Link } from 'react-router-dom';
+
+interface MembershipCardProps {
+  membership: Membership;
+}
+
+interface AdminTagProps {
+  isAdmin: boolean;
+}
+const AdminTag: React.FC<AdminTagProps> = (props: AdminTagProps) => {
+  if (props.isAdmin) {
+    return <span className="tag is-primary">Admin</span>;
+  } else {
+    return <span className="tag is-dark">NOT Admin</span>;
+  }
+};
+const MembershipCard: React.FC<MembershipCardProps> = (
+  props: MembershipCardProps
+) => {
+  let membership = props.membership;
+  return (
+    <Link className="box" to={'/organizations/' + membership.organization}>
+      <h5 className="title is-size-5">{membership.organization}</h5>
+      <div className="field is-grouped is-grouped-multiline">
+        <div className="control">
+          <div className="tags has-addons"></div>
+          <AdminTag isAdmin={membership.admin} />
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default MembershipCard;

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Organization } from "../store/organizations/types";
+import { Link } from "react-router-dom";
+
+interface OrganizationCardProps {
+  organization: Organization;
+}
+
+const OrganizationCard: React.FC<OrganizationCardProps> = (props: OrganizationCardProps) => {
+  let organization = props.organization;
+  return (
+    <Link className="box" to={"/organizations/" + organization.uuid}>
+      <h5 className="title is-size-5">{organization.name}</h5>
+      <div className="field is-grouped is-grouped-multiline">
+        <div className="control">
+          <div className="tags has-addons">
+            <span className="tag is-dark">Organization ID</span>
+            <span className="tag is-primary">{organization.uuid}</span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default OrganizationCard;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -23,12 +23,16 @@ import { upsertSelfUser } from "./users/actions";
 import { usersReducers } from "./users/reducers";
 import { UsersState } from "./users/types";
 
-
+// Organizations
+import { upsertOrganization, upsertOrganizations, deleteOrganization } from "./organizations/actions";
+import { organizationReducers } from "./organizations/reducers";
+import { OrganizationState } from "./organizations/types";
 
 const reducers = combineReducers({
   auth: authReducers,
   clients: clientReducers,
   entitlements: entitlementReducers,
+  organizations: organizationReducers,
   users: usersReducers
 });
 
@@ -47,6 +51,9 @@ export interface AppActions {
   upsertClient: typeof upsertClient;
   upsertClients: typeof upsertClients;
   deleteClient: typeof deleteClient;
+  upsertOrganization: typeof upsertOrganization;
+  upsertOrganizations: typeof upsertOrganizations;
+  deleteOrganization: typeof deleteOrganization;
   upsertEntitlement: typeof upsertEntitlement;
   upsertEntitlements: typeof upsertEntitlements;
   deleteEntitlement: typeof deleteEntitlement;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -36,6 +36,15 @@ import {
 import { organizationReducers } from './organizations/reducers';
 import { OrganizationState } from './organizations/types';
 
+//`Memberships
+import {
+  upsertInvitation,
+  upsertInvitations,
+  deleteInvitation
+} from './invitations/actions';
+import { invitationReducers } from './invitations/reducers';
+import { InvitationState } from './invitations/types';
+
 // Memberships
 import {
   upsertMembership,
@@ -50,6 +59,7 @@ const reducers = combineReducers({
   clients: clientReducers,
   entitlements: entitlementReducers,
   organizations: organizationReducers,
+  invitations: invitationReducers,
   memberships: membershipReducers,
   users: usersReducers
 });
@@ -75,6 +85,9 @@ export interface AppActions {
   upsertMembership: typeof upsertMembership;
   upsertMemberships: typeof upsertMemberships;
   deleteMembership: typeof deleteMembership;
+  upsertInvitation: typeof upsertInvitation;
+  upsertInvitations: typeof upsertInvitations;
+  deleteInvitation: typeof deleteInvitation;
   upsertEntitlement: typeof upsertEntitlement;
   upsertEntitlements: typeof upsertEntitlements;
   deleteEntitlement: typeof deleteEntitlement;
@@ -87,6 +100,7 @@ export interface AppProps {
   clients: ClientState;
   entitlements: EntitlementState;
   organizations: OrganizationState;
+  invitations: InvitationState;
   memberships: MembershipState;
   users: UsersState;
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,32 +1,40 @@
 // Redux & external redux libs
-import { composeWithDevTools } from "redux-devtools-extension";
-import { createStore, applyMiddleware, combineReducers } from "redux";
-import thunkMiddleware from "redux-thunk";
+import { composeWithDevTools } from 'redux-devtools-extension';
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 
 // Auth
-import { login, logout } from "./auth/actions";
-import { authReducers } from "./auth/reducers";
-import { AuthState } from "./auth/types";
+import { login, logout } from './auth/actions';
+import { authReducers } from './auth/reducers';
+import { AuthState } from './auth/types';
 
 // Clients
-import { upsertClient, upsertClients, deleteClient } from "./clients/actions";
-import { clientReducers } from "./clients/reducers";
-import { ClientState } from "./clients/types";
+import { upsertClient, upsertClients, deleteClient } from './clients/actions';
+import { clientReducers } from './clients/reducers';
+import { ClientState } from './clients/types';
 
 // Entitlements
-import { upsertEntitlement, upsertEntitlements, deleteEntitlement } from "./entitlements/actions";
-import { entitlementReducers } from "./entitlements/reducers";
-import { EntitlementState } from "./entitlements/types";
+import {
+  upsertEntitlement,
+  upsertEntitlements,
+  deleteEntitlement
+} from './entitlements/actions';
+import { entitlementReducers } from './entitlements/reducers';
+import { EntitlementState } from './entitlements/types';
 
 // Users
-import { upsertSelfUser } from "./users/actions";
-import { usersReducers } from "./users/reducers";
-import { UsersState } from "./users/types";
+import { upsertSelfUser } from './users/actions';
+import { usersReducers } from './users/reducers';
+import { UsersState } from './users/types';
 
 // Organizations
-import { upsertOrganization, upsertOrganizations, deleteOrganization } from "./organizations/actions";
-import { organizationReducers } from "./organizations/reducers";
-import { OrganizationState } from "./organizations/types";
+import {
+  upsertOrganization,
+  upsertOrganizations,
+  deleteOrganization
+} from './organizations/actions';
+import { organizationReducers } from './organizations/reducers';
+import { OrganizationState } from './organizations/types';
 
 const reducers = combineReducers({
   auth: authReducers,
@@ -65,6 +73,7 @@ export interface AppProps {
   actions: AppActions;
   clients: ClientState;
   entitlements: EntitlementState;
+  organizations: OrganizationState;
   users: UsersState;
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -36,11 +36,21 @@ import {
 import { organizationReducers } from './organizations/reducers';
 import { OrganizationState } from './organizations/types';
 
+// Memberships
+import {
+  upsertMembership,
+  upsertMemberships,
+  deleteMembership
+} from './memberships/actions';
+import { membershipReducers } from './memberships/reducers';
+import { MembershipState } from './memberships/types';
+
 const reducers = combineReducers({
   auth: authReducers,
   clients: clientReducers,
   entitlements: entitlementReducers,
   organizations: organizationReducers,
+  memberships: membershipReducers,
   users: usersReducers
 });
 
@@ -62,6 +72,9 @@ export interface AppActions {
   upsertOrganization: typeof upsertOrganization;
   upsertOrganizations: typeof upsertOrganizations;
   deleteOrganization: typeof deleteOrganization;
+  upsertMembership: typeof upsertMembership;
+  upsertMemberships: typeof upsertMemberships;
+  deleteMembership: typeof deleteMembership;
   upsertEntitlement: typeof upsertEntitlement;
   upsertEntitlements: typeof upsertEntitlements;
   deleteEntitlement: typeof deleteEntitlement;
@@ -74,6 +87,7 @@ export interface AppProps {
   clients: ClientState;
   entitlements: EntitlementState;
   organizations: OrganizationState;
+  memberships: MembershipState;
   users: UsersState;
 }
 

--- a/src/store/invitations/actions.ts
+++ b/src/store/invitations/actions.ts
@@ -1,0 +1,46 @@
+import {
+  UPSERT_INVITATION,
+  UPSERT_INVITATIONS,
+  Invitation,
+  DELETE_INVITATION,
+  DeleteInvitationAction,
+  UpsertInvitationAction,
+  UpsertInvitationsAction
+} from './types';
+
+export function upsertInvitation(
+  invitation: Invitation
+): UpsertInvitationAction {
+  return {
+    type: UPSERT_INVITATION,
+    invitation: invitation
+  };
+}
+
+// This action is necessary because if one wants to
+// upsert multiple organizations into the store at load time,
+// calling each `upsertOrganization` individually would cause
+// the 'hydrated' field to be set to `true` after the first
+// upsert (but before all the data has been loaded). This
+// can cause issues when there are multiple organizations,
+// as a view might be waiting for `hydrated` to be `true`
+// before displaying data from a particular organization. If
+// `hydrated` is set to `true` too early, this can cause
+// these views to fail.
+export function upsertInvitations(
+  invitations: Invitation[]
+): UpsertInvitationsAction {
+  return {
+    type: UPSERT_INVITATIONS,
+    invitations: invitations
+  };
+}
+
+export function deleteInvitation(
+  invitation: Invitation
+): DeleteInvitationAction {
+  return {
+    type: DELETE_INVITATION,
+    invitation: invitation
+  };
+}

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -1,0 +1,163 @@
+import { AppActions } from '..';
+import {
+  checkAuth,
+  cfetch,
+  validate,
+  ItemizedResponse,
+  notify,
+  GET,
+  PATCH,
+  PUT,
+  DELETE
+} from '../../utils';
+import { Invitation, InvitationState } from './types';
+import { OrganizationState, Organization } from '../organizations/types';
+
+const serializeInvitation = (invitation: Invitation) => ({
+  user: invitation.user,
+  organization: invitation.organization,
+  request: invitation.request
+  // not all of the fields in invitation are write-available, and
+  // including them in the request would result in a 400 response.
+});
+
+export const fetchInvitationsForUser = (actions: AppActions, uuid: string) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/users/${uuid}/invitations`,
+    GET
+  )
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertInvitations(data.results)]))
+    .catch(error => {
+      console.error('API Error fetchInvitationsForUser', error, error.code);
+    });
+
+export const ensureInvitationsForUser = (
+  actions: AppActions,
+  uuid: string,
+  invitations: InvitationState
+) => {
+  if (!invitations.hydrated) {
+    return fetchInvitationsForUser(actions, uuid);
+  }
+};
+
+export const fetchInvitationsForOrganizations = (
+  actions: AppActions,
+  organizations: OrganizationState,
+  invitations: InvitationState
+) => {
+  Object.values(organizations.organizations).map(
+    (organization: Organization) => {
+      cfetch(
+        `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization.uuid}/invitations`,
+        GET
+      )
+        .then(checkAuth(actions))
+        .then(response => response.json())
+        .then(data => Promise.all([actions.upsertInvitations(data.results)]))
+        .catch(error => {
+          console.error(
+            'API Error fetchInvitationsForOrganizations',
+            error,
+            error.code
+          );
+        });
+    }
+  );
+};
+
+export const fetchInvitationsForOrganization = (
+  actions: AppActions,
+  uuid: string
+) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/invitations`,
+    GET
+  )
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertInvitations(data.results)]))
+    .catch(error => {
+      console.error('API Error fetchInvitationsForUser', error, error.code);
+    });
+
+export const ensureInvitationsForOrganization = (
+  actions: AppActions,
+  uuid: string,
+  invitations: InvitationState
+) => {
+  if (!invitations.hydrated) {
+    return fetchInvitationsForOrganization(actions, uuid);
+  }
+};
+
+export const updateInvitation = (
+  invitation: Invitation,
+  actions: AppActions
+) => {
+  let formData = new FormData();
+  let packagedInvitation: any = serializeInvitation(invitation);
+  for (let key of Object.keys(packagedInvitation)) {
+    formData.append(key, packagedInvitation[key]);
+  }
+  return cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${invitation.organization}/invitations/${invitation.user}/`,
+    PATCH(formData)
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertInvitation(status.body as Invitation);
+        notify(
+          `Successfully updated user ${invitation.user}'s invitation in organization ${invitation.organization}.`,
+          'success'
+        );
+      })
+    );
+};
+
+export const createInvitation = (
+  invitation: Invitation,
+  actions: AppActions
+) => {
+  let formData = new FormData();
+  let packagedInvitation: any = serializeInvitation(invitation);
+  for (let key of Object.keys(packagedInvitation)) {
+    formData.append(key, packagedInvitation[key]);
+  }
+  return (
+    cfetch(
+      `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${invitation.organization}/invitations/${invitation.user}`,
+      PUT(formData)
+    )
+      .then(checkAuth(actions))
+      // Cannot call upsert invitation here, because IDs are assigned on the server side
+      .then(response =>
+        validate(response, (status: ItemizedResponse) => {
+          actions.upsertInvitation(status.body as Invitation);
+          notify(
+            `Successfully created invitation for user ${invitation.user} in organization ${invitation.organization}.`,
+            'success'
+          );
+        })
+      )
+  );
+};
+
+export const deleteInvitation = (invitation: Invitation, actions: AppActions) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${invitation.organization}/invitations/${invitation.user}`,
+    DELETE
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, () => {
+        actions.deleteInvitation(invitation);
+        notify(
+          `Successfully deleted user ${invitation.user} from organization ${invitation.organization}.`,
+          'success'
+        );
+      })
+    );

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -27,11 +27,12 @@ export function invitationReducers(
       return Object.assign({}, state, incomingObject);
     }
     case UPSERT_INVITATION: {
+      console.log(state, action.invitation.user);
       let incomingObject: InvitationState = {
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      incomingObject.invitations[action.invitation.user] = action.invitation;
+      incomingObject.invitations[action.invitation.organization] = action.invitation;
       return Object.assign({}, state, incomingObject);
     }
     case DELETE_INVITATION: {
@@ -39,7 +40,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      delete incomingObject.invitations[action.invitation.user];
+      delete incomingObject.invitations[action.invitation.organization];
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -27,7 +27,6 @@ export function invitationReducers(
       return Object.assign({}, state, incomingObject);
     }
     case UPSERT_INVITATION: {
-      console.log(state, action.invitation.user);
       let incomingObject: InvitationState = {
         invitations: Object.assign({}, state.invitations),
         hydrated: true

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -1,0 +1,48 @@
+import {
+  InvitationAction,
+  UPSERT_INVITATION,
+  InvitationState,
+  UPSERT_INVITATIONS,
+  DELETE_INVITATION
+} from './types';
+
+const initialState: InvitationState = {
+  invitations: {},
+  hydrated: false
+};
+
+export function invitationReducers(
+  state = initialState,
+  action: InvitationAction
+): InvitationState {
+  switch (action.type) {
+    case UPSERT_INVITATIONS: {
+      let incomingObject: InvitationState = {
+        invitations: Object.assign({}, state.invitations),
+        hydrated: true
+      };
+      for (let invitation of action.invitations) {
+        incomingObject.invitations[invitation.organization] = invitation;
+      }
+      return Object.assign({}, state, incomingObject);
+    }
+    case UPSERT_INVITATION: {
+      let incomingObject: InvitationState = {
+        invitations: Object.assign({}, state.invitations),
+        hydrated: true
+      };
+      incomingObject.invitations[action.invitation.user] = action.invitation;
+      return Object.assign({}, state, incomingObject);
+    }
+    case DELETE_INVITATION: {
+      let incomingObject: InvitationState = {
+        invitations: Object.assign({}, state.invitations),
+        hydrated: true
+      };
+      delete incomingObject.invitations[action.invitation.user];
+      return Object.assign({}, state, incomingObject);
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -1,0 +1,37 @@
+export const DELETE_INVITATION = 'DELETE_INVITATION';
+export const UPSERT_INVITATION = 'UPSERT_INVITATION';
+export const UPSERT_INVITATIONS = 'UPSERT_INVITATIONS';
+
+export interface Invitation {
+  organization: number;
+  user: number;
+  request: boolean;
+  created_at: Date;
+  accepted_at: Date;
+  rejected_at: Date;
+}
+
+export interface InvitationState {
+  invitations: { [id: number]: Invitation };
+  hydrated: boolean;
+}
+
+export interface UpsertInvitationAction {
+  type: typeof UPSERT_INVITATION;
+  invitation: Invitation;
+}
+
+export interface UpsertInvitationsAction {
+  type: typeof UPSERT_INVITATIONS;
+  invitations: Invitation[];
+}
+
+export interface DeleteInvitationAction {
+  type: typeof DELETE_INVITATION;
+  invitation: Invitation;
+}
+
+export type InvitationAction =
+  | UpsertInvitationAction
+  | UpsertInvitationsAction
+  | DeleteInvitationAction;

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -3,12 +3,15 @@ export const UPSERT_INVITATION = 'UPSERT_INVITATION';
 export const UPSERT_INVITATIONS = 'UPSERT_INVITATIONS';
 
 export interface Invitation {
+  uuid: number;
   organization: number;
   user: number;
   request: boolean;
   created_at: Date;
   accepted_at: Date;
   rejected_at: Date;
+  accept: boolean;
+  reject: boolean;
 }
 
 export interface InvitationState {

--- a/src/store/memberships/actions.ts
+++ b/src/store/memberships/actions.ts
@@ -1,0 +1,46 @@
+import {
+  UPSERT_MEMBERSHIP,
+  UPSERT_MEMBERSHIPS,
+  Membership,
+  DELETE_MEMBERSHIP,
+  DeleteMembershipAction,
+  UpsertMembershipAction,
+  UpsertMembershipsAction
+} from './types';
+
+export function upsertMembership(
+  membership: Membership
+): UpsertMembershipAction {
+  return {
+    type: UPSERT_MEMBERSHIP,
+    membership: membership
+  };
+}
+
+// This action is necessary because if one wants to
+// upsert multiple organizations into the store at load time,
+// calling each `upsertOrganization` individually would cause
+// the 'hydrated' field to be set to `true` after the first
+// upsert (but before all the data has been loaded). This
+// can cause issues when there are multiple organizations,
+// as a view might be waiting for `hydrated` to be `true`
+// before displaying data from a particular organization. If
+// `hydrated` is set to `true` too early, this can cause
+// these views to fail.
+export function upsertMemberships(
+  memberships: Membership[]
+): UpsertMembershipsAction {
+  return {
+    type: UPSERT_MEMBERSHIPS,
+    memberships: memberships
+  };
+}
+
+export function deleteMembership(
+  membership: Membership
+): DeleteMembershipAction {
+  return {
+    type: DELETE_MEMBERSHIP,
+    membership: membership
+  };
+}

--- a/src/store/memberships/api.ts
+++ b/src/store/memberships/api.ts
@@ -1,0 +1,116 @@
+import { AppActions } from '..';
+import {
+  checkAuth,
+  cfetch,
+  validate,
+  ItemizedResponse,
+  notify,
+  GET,
+  PATCH,
+  PUT,
+  DELETE
+} from '../../utils';
+import { Membership, MembershipState } from './types';
+
+const serializeMembership = (membership: Membership) => ({
+  user: membership.user,
+  organization: membership.organization,
+  admin: membership.admin
+  // Explicitly setting each field is necessary here, because
+  // not all of the fields in membership are write-available, and
+  // including them in the request would result in a 400 response.
+});
+
+export const fetchMembershipsForOrganization = (
+  actions: AppActions,
+  uuid: string
+) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/memberships`,
+    GET
+  )
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertMemberships(data.results)]))
+    .catch(error => {
+      console.error('API Error fetchMembershipsForUser', error, error.code);
+    });
+
+export const ensureMembershipsForOrganization = (
+  actions: AppActions,
+  uuid: string,
+  memberships: MembershipState
+) => {
+  if (!memberships.hydrated) {
+    return fetchMembershipsForOrganization(actions, uuid);
+  }
+};
+
+export const updateMembership = (
+  membership: Membership,
+  actions: AppActions
+) => {
+  let formData = new FormData();
+  let packagedMembership: any = serializeMembership(membership);
+  for (let key of Object.keys(packagedMembership)) {
+    formData.append(key, packagedMembership[key]);
+  }
+  return cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${membership.organization}/memberships/${membership.user}/`,
+    PATCH(formData)
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertMembership(status.body as Membership);
+        notify(
+          `Successfully updated user ${membership.user}'s membership in organization ${membership.organization}.`,
+          'success'
+        );
+      })
+    );
+};
+
+export const createMembership = (
+  membership: Membership,
+  actions: AppActions
+) => {
+  let formData = new FormData();
+  let packagedMembership: any = serializeMembership(membership);
+  for (let key of Object.keys(packagedMembership)) {
+    formData.append(key, packagedMembership[key]);
+  }
+  return (
+    cfetch(
+      `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${membership.organization}/memberships/${membership.user}`,
+      PUT(formData)
+    )
+      .then(checkAuth(actions))
+      // Cannot call upsert membership here, because IDs are assigned on the server side
+      .then(response =>
+        validate(response, (status: ItemizedResponse) => {
+          actions.upsertMembership(status.body as Membership);
+          notify(
+            `Successfully created membership for user ${membership.user} in organization ${membership.organization}.`,
+            'success'
+          );
+        })
+      )
+  );
+};
+
+export const deleteMembership = (membership: Membership, actions: AppActions) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${membership.organization}/memberships/${membership.user}`,
+    DELETE
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, () => {
+        actions.deleteMembership(membership);
+        notify(
+          `Successfully deleted user ${membership.user} from organization ${membership.organization}.`,
+          'success'
+        );
+      })
+    );

--- a/src/store/memberships/reducers.ts
+++ b/src/store/memberships/reducers.ts
@@ -22,7 +22,7 @@ export function membershipReducers(
         hydrated: true
       };
       for (let membership of action.memberships) {
-        incomingObject.memberships[membership.user] = membership;
+        incomingObject.memberships[membership.organization] = membership;
       }
       return Object.assign({}, state, incomingObject);
     }

--- a/src/store/memberships/reducers.ts
+++ b/src/store/memberships/reducers.ts
@@ -1,0 +1,48 @@
+import {
+  MembershipAction,
+  UPSERT_MEMBERSHIP,
+  MembershipState,
+  UPSERT_MEMBERSHIPS,
+  DELETE_MEMBERSHIP
+} from './types';
+
+const initialState: MembershipState = {
+  memberships: {},
+  hydrated: false
+};
+
+export function membershipReducers(
+  state = initialState,
+  action: MembershipAction
+): MembershipState {
+  switch (action.type) {
+    case UPSERT_MEMBERSHIPS: {
+      let incomingObject: MembershipState = {
+        memberships: Object.assign({}, state.memberships),
+        hydrated: true
+      };
+      for (let membership of action.memberships) {
+        incomingObject.memberships[membership.user] = membership;
+      }
+      return Object.assign({}, state, incomingObject);
+    }
+    case UPSERT_MEMBERSHIP: {
+      let incomingObject: MembershipState = {
+        memberships: Object.assign({}, state.memberships),
+        hydrated: true
+      };
+      incomingObject.memberships[action.membership.user] = action.membership;
+      return Object.assign({}, state, incomingObject);
+    }
+    case DELETE_MEMBERSHIP: {
+      let incomingObject: MembershipState = {
+        memberships: Object.assign({}, state.memberships),
+        hydrated: true
+      };
+      delete incomingObject.memberships[action.membership.user];
+      return Object.assign({}, state, incomingObject);
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/memberships/types.ts
+++ b/src/store/memberships/types.ts
@@ -1,0 +1,34 @@
+export const DELETE_MEMBERSHIP = 'DELETE_MEMBERSHIP';
+export const UPSERT_MEMBERSHIP = 'UPSERT_MEMBERSHIP';
+export const UPSERT_MEMBERSHIPS = 'UPSERT_MEMBERSHIPS';
+
+export interface Membership {
+  user: number;
+  organization: number;
+  admin: boolean;
+}
+
+export interface MembershipState {
+  memberships: { [id: number]: Membership };
+  hydrated: boolean;
+}
+
+export interface UpsertMembershipAction {
+  type: typeof UPSERT_MEMBERSHIP;
+  membership: Membership;
+}
+
+export interface UpsertMembershipsAction {
+  type: typeof UPSERT_MEMBERSHIPS;
+  memberships: Membership[];
+}
+
+export interface DeleteMembershipAction {
+  type: typeof DELETE_MEMBERSHIP;
+  membership: Membership;
+}
+
+export type MembershipAction =
+  | UpsertMembershipAction
+  | UpsertMembershipsAction
+  | DeleteMembershipAction;

--- a/src/store/organizations/actions.ts
+++ b/src/store/organizations/actions.ts
@@ -30,7 +30,6 @@ export function upsertOrganization(
 export function upsertOrganizations(
   organizations: Organization[]
 ): UpsertOrganizationsAction {
-  console.log(organizations);
   return {
     type: UPSERT_ORGANIZATIONS,
     organizations: organizations

--- a/src/store/organizations/actions.ts
+++ b/src/store/organizations/actions.ts
@@ -6,9 +6,11 @@ import {
   DeleteOrganizationAction,
   UpsertOrganizationAction,
   UpsertOrganizationsAction
-} from "./types";
+} from './types';
 
-export function upsertOrganization(organization: Organization): UpsertOrganizationAction {
+export function upsertOrganization(
+  organization: Organization
+): UpsertOrganizationAction {
   return {
     type: UPSERT_ORGANIZATION,
     organization: organization
@@ -25,14 +27,19 @@ export function upsertOrganization(organization: Organization): UpsertOrganizati
 // before displaying data from a particular organization. If
 // `hydrated` is set to `true` too early, this can cause
 // these views to fail.
-export function upsertOrganizations(organizations: Organization[]): UpsertOrganizationsAction {
+export function upsertOrganizations(
+  organizations: Organization[]
+): UpsertOrganizationsAction {
+  console.log(organizations);
   return {
     type: UPSERT_ORGANIZATIONS,
     organizations: organizations
   };
 }
 
-export function deleteOrganization(organization: Organization): DeleteOrganizationAction {
+export function deleteOrganization(
+  organization: Organization
+): DeleteOrganizationAction {
   return {
     type: DELETE_ORGANIZATION,
     organization: organization

--- a/src/store/organizations/actions.ts
+++ b/src/store/organizations/actions.ts
@@ -1,0 +1,40 @@
+import {
+  UPSERT_ORGANIZATION,
+  Organization,
+  UPSERT_ORGANIZATIONS,
+  DELETE_ORGANIZATION,
+  DeleteOrganizationAction,
+  UpsertOrganizationAction,
+  UpsertOrganizationsAction
+} from "./types";
+
+export function upsertOrganization(organization: Organization): UpsertOrganizationAction {
+  return {
+    type: UPSERT_ORGANIZATION,
+    organization: organization
+  };
+}
+
+// This action is necessary because if one wants to
+// upsert multiple organizations into the store at load time,
+// calling each `upsertOrganization` individually would cause
+// the 'hydrated' field to be set to `true` after the first
+// upsert (but before all the data has been loaded). This
+// can cause issues when there are multiple organizations,
+// as a view might be waiting for `hydrated` to be `true`
+// before displaying data from a particular organization. If
+// `hydrated` is set to `true` too early, this can cause
+// these views to fail.
+export function upsertOrganizations(organizations: Organization[]): UpsertOrganizationsAction {
+  return {
+    type: UPSERT_ORGANIZATIONS,
+    organizations: organizations
+  };
+}
+
+export function deleteOrganization(organization: Organization): DeleteOrganizationAction {
+  return {
+    type: DELETE_ORGANIZATION,
+    organization: organization
+  };
+}

--- a/src/store/organizations/api.ts
+++ b/src/store/organizations/api.ts
@@ -1,0 +1,96 @@
+import { AppActions } from "..";
+import {
+  checkAuth,
+  cfetch,
+  validate,
+  ItemizedResponse,
+  notify,
+  GET,
+  PATCH,
+  POST,
+  DELETE
+} from "../../utils";
+import { Organization, OrganizationState } from "./types";
+
+const serializeOrganization = (organization: Organization) => ({
+  uuid: organization.uuid,
+  name: organization.name || "",
+  avatar: organization.avatar || "",
+  slug: organization.slug,
+  plan: organization.plan,
+  max_users: organization.max_users,
+  individual: organization.individual,
+  private: organization.private,
+  // Explicitly setting each field is necessary here, because
+  // not all of the fields in organization are write-available, and
+  // including them in the request would result in a 400 response.
+});
+
+export const fetchOrganizations = (actions: AppActions) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/organizations/`, GET)
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertOrganizations(data.results)]))
+    .catch(error => {
+      console.error("API Error fetchOrganizations", error, error.code);
+    });
+
+export const ensureOrganizations = (actions: AppActions, organizations: OrganizationState) => {
+  if (!organizations.hydrated) {
+    return fetchOrganizations(actions);
+  }
+};
+
+export const updateOrganization = (organization: Organization, actions: AppActions) => {
+  let formData = new FormData();
+  let packagedOrganization: any = serializeOrganization(organization);
+  for (let key of Object.keys(packagedOrganization)) {
+    formData.append(key, packagedOrganization[key]);
+  }
+  return cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization.uuid}/`,
+    PATCH(formData)
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertOrganization(status.body as Organization);
+        notify(`Successfully updated ${organization.name}.`, "success");
+      })
+    );
+};
+
+export const createOrganization = (organization: Organization, actions: AppActions) => {
+  let formData = new FormData();
+  let packagedOrganization: any = serializeOrganization(organization);
+  for (let key of Object.keys(packagedOrganization)) {
+    formData.append(key, packagedOrganization[key]);
+  }
+  return (
+    cfetch(
+      `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/`,
+      POST(formData)
+    )
+      .then(checkAuth(actions))
+      // Cannot call upsert organization here, because IDs are assigned on the server side
+      .then(response =>
+        validate(response, (status: ItemizedResponse) => {
+          actions.upsertOrganization(status.body as Organization);
+          notify(`Successfully created ${organization.name}.`, "success");
+        })
+      )
+  );
+};
+
+export const deleteOrganization = (organization: Organization, actions: AppActions) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization.uuid}`,
+    DELETE
+  )
+    .then(checkAuth(actions))
+    .then(response =>
+      validate(response, () => {
+        actions.deleteOrganization(organization);
+        notify(`Successfully deleted ${organization.name}.`, "success");
+      })
+    );

--- a/src/store/organizations/api.ts
+++ b/src/store/organizations/api.ts
@@ -1,4 +1,4 @@
-import { AppActions } from "..";
+import { AppActions } from '..';
 import {
   checkAuth,
   cfetch,
@@ -9,18 +9,18 @@ import {
   PATCH,
   POST,
   DELETE
-} from "../../utils";
-import { Organization, OrganizationState } from "./types";
+} from '../../utils';
+import { Organization, OrganizationState } from './types';
 
 const serializeOrganization = (organization: Organization) => ({
   uuid: organization.uuid,
-  name: organization.name || "",
-  avatar: organization.avatar || "",
+  name: organization.name || '',
+  avatar: organization.avatar || '',
   slug: organization.slug,
   plan: organization.plan,
   max_users: organization.max_users,
   individual: organization.individual,
-  private: organization.private,
+  private: organization.private
   // Explicitly setting each field is necessary here, because
   // not all of the fields in organization are write-available, and
   // including them in the request would result in a 400 response.
@@ -32,16 +32,44 @@ export const fetchOrganizations = (actions: AppActions) =>
     .then(response => response.json())
     .then(data => Promise.all([actions.upsertOrganizations(data.results)]))
     .catch(error => {
-      console.error("API Error fetchOrganizations", error, error.code);
+      console.error('API Error fetchOrganizations', error, error.code);
     });
 
-export const ensureOrganizations = (actions: AppActions, organizations: OrganizationState) => {
+export const ensureOrganizations = (
+  actions: AppActions,
+  organizations: OrganizationState
+) => {
   if (!organizations.hydrated) {
     return fetchOrganizations(actions);
   }
 };
 
-export const updateOrganization = (organization: Organization, actions: AppActions) => {
+export const fetchOrganizationsForUser = (actions: AppActions, uuid: string) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/?user=${uuid}`,
+    GET
+  )
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertOrganizations(data.results)]))
+    .catch(error => {
+      console.error('API Error fetchOrganizationsForUser', error, error.code);
+    });
+
+export const ensureOrganizationsForUser = (
+  actions: AppActions,
+  uuid: string,
+  organizations: OrganizationState
+) => {
+  if (!organizations.hydrated) {
+    return fetchOrganizationsForUser(actions, uuid);
+  }
+};
+
+export const updateOrganization = (
+  organization: Organization,
+  actions: AppActions
+) => {
   let formData = new FormData();
   let packagedOrganization: any = serializeOrganization(organization);
   for (let key of Object.keys(packagedOrganization)) {
@@ -55,12 +83,15 @@ export const updateOrganization = (organization: Organization, actions: AppActio
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
         actions.upsertOrganization(status.body as Organization);
-        notify(`Successfully updated ${organization.name}.`, "success");
+        notify(`Successfully updated ${organization.name}.`, 'success');
       })
     );
 };
 
-export const createOrganization = (organization: Organization, actions: AppActions) => {
+export const createOrganization = (
+  organization: Organization,
+  actions: AppActions
+) => {
   let formData = new FormData();
   let packagedOrganization: any = serializeOrganization(organization);
   for (let key of Object.keys(packagedOrganization)) {
@@ -76,13 +107,16 @@ export const createOrganization = (organization: Organization, actions: AppActio
       .then(response =>
         validate(response, (status: ItemizedResponse) => {
           actions.upsertOrganization(status.body as Organization);
-          notify(`Successfully created ${organization.name}.`, "success");
+          notify(`Successfully created ${organization.name}.`, 'success');
         })
       )
   );
 };
 
-export const deleteOrganization = (organization: Organization, actions: AppActions) =>
+export const deleteOrganization = (
+  organization: Organization,
+  actions: AppActions
+) =>
   cfetch(
     `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization.uuid}`,
     DELETE
@@ -91,6 +125,6 @@ export const deleteOrganization = (organization: Organization, actions: AppActio
     .then(response =>
       validate(response, () => {
         actions.deleteOrganization(organization);
-        notify(`Successfully deleted ${organization.name}.`, "success");
+        notify(`Successfully deleted ${organization.name}.`, 'success');
       })
     );

--- a/src/store/organizations/api.ts
+++ b/src/store/organizations/api.ts
@@ -44,28 +44,6 @@ export const ensureOrganizations = (
   }
 };
 
-export const fetchOrganizationsForUser = (actions: AppActions, uuid: string) =>
-  cfetch(
-    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/?user=${uuid}`,
-    GET
-  )
-    .then(checkAuth(actions))
-    .then(response => response.json())
-    .then(data => Promise.all([actions.upsertOrganizations(data.results)]))
-    .catch(error => {
-      console.error('API Error fetchOrganizationsForUser', error, error.code);
-    });
-
-export const ensureOrganizationsForUser = (
-  actions: AppActions,
-  uuid: string,
-  organizations: OrganizationState
-) => {
-  if (!organizations.hydrated) {
-    return fetchOrganizationsForUser(actions, uuid);
-  }
-};
-
 export const updateOrganization = (
   organization: Organization,
   actions: AppActions

--- a/src/store/organizations/reducers.ts
+++ b/src/store/organizations/reducers.ts
@@ -4,7 +4,7 @@ import {
   OrganizationState,
   UPSERT_ORGANIZATIONS,
   DELETE_ORGANIZATION
-} from "./types";
+} from './types';
 
 const initialState: OrganizationState = {
   organizations: {},
@@ -31,7 +31,8 @@ export function organizationReducers(
         organizations: Object.assign({}, state.organizations),
         hydrated: true
       };
-      incomingObject.organizations[action.organization.id] = action.organization;
+      incomingObject.organizations[action.organization.uuid] =
+        action.organization;
       return Object.assign({}, state, incomingObject);
     }
     case DELETE_ORGANIZATION: {
@@ -39,7 +40,7 @@ export function organizationReducers(
         organizations: Object.assign({}, state.organizations),
         hydrated: true
       };
-      delete incomingObject.organizations[action.organization.id];
+      delete incomingObject.organizations[action.organization.uuid];
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/organizations/reducers.ts
+++ b/src/store/organizations/reducers.ts
@@ -1,0 +1,48 @@
+import {
+  OrganizationAction,
+  UPSERT_ORGANIZATION,
+  OrganizationState,
+  UPSERT_ORGANIZATIONS,
+  DELETE_ORGANIZATION
+} from "./types";
+
+const initialState: OrganizationState = {
+  organizations: {},
+  hydrated: false
+};
+
+export function organizationReducers(
+  state = initialState,
+  action: OrganizationAction
+): OrganizationState {
+  switch (action.type) {
+    case UPSERT_ORGANIZATIONS: {
+      let incomingObject: OrganizationState = {
+        organizations: Object.assign({}, state.organizations),
+        hydrated: true
+      };
+      for (let organization of action.organizations) {
+        incomingObject.organizations[organization.uuid] = organization;
+      }
+      return Object.assign({}, state, incomingObject);
+    }
+    case UPSERT_ORGANIZATION: {
+      let incomingObject: OrganizationState = {
+        organizations: Object.assign({}, state.organizations),
+        hydrated: true
+      };
+      incomingObject.organizations[action.organization.id] = action.organization;
+      return Object.assign({}, state, incomingObject);
+    }
+    case DELETE_ORGANIZATION: {
+      let incomingObject: OrganizationState = {
+        organizations: Object.assign({}, state.organizations),
+        hydrated: true
+      };
+      delete incomingObject.organizations[action.organization.id];
+      return Object.assign({}, state, incomingObject);
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/organizations/types.ts
+++ b/src/store/organizations/types.ts
@@ -1,8 +1,6 @@
 export const UPSERT_ORGANIZATION = 'UPSERT_ORGANIZATION';
 export const UPSERT_ORGANIZATIONS = 'UPSERT_ORGANIZATIONS';
 export const DELETE_ORGANIZATION = 'DELETE_ORGANIZATION';
-export const UPSERT_INVITATION = 'UPSERT_INVITATION';
-export const UPSERT_MEMBERSHIP = 'UPSERT_MEMBERSHIP';
 
 export interface Organization {
   uuid: string;
@@ -21,16 +19,6 @@ export interface Organization {
 export interface OrganizationState {
   organizations: { [id: number]: Organization };
   hydrated: boolean;
-}
-
-export interface Invitation {
-  organization: number;
-  email: string;
-  user: number;
-  request: boolean;
-  created_at: Date;
-  accepted_at: Date;
-  rejected_at: Date;
 }
 
 export interface UpsertOrganizationAction {

--- a/src/store/organizations/types.ts
+++ b/src/store/organizations/types.ts
@@ -1,8 +1,8 @@
-export const UPSERT_ORGANIZATION = "UPSERT_ORGANIZATION";
-export const UPSERT_ORGANIZATIONS = "UPSERT_ORGANIZATIONS";
-export const DELETE_ORGANIZATION = "DELETE_ORGANIZATION";
-export const UPSERT_INVITATION = "UPSERT_INVITATION";
-export const UPSERT_MEMBERSHIP = "UPSERT_MEMBERSHIP";
+export const UPSERT_ORGANIZATION = 'UPSERT_ORGANIZATION';
+export const UPSERT_ORGANIZATIONS = 'UPSERT_ORGANIZATIONS';
+export const DELETE_ORGANIZATION = 'DELETE_ORGANIZATION';
+export const UPSERT_INVITATION = 'UPSERT_INVITATION';
+export const UPSERT_MEMBERSHIP = 'UPSERT_MEMBERSHIP';
 
 export interface Organization {
   uuid: string;
@@ -31,11 +31,6 @@ export interface Invitation {
   created_at: Date;
   accepted_at: Date;
   rejected_at: Date;
-}
-
-export interface Membership {
-  user: number;
-  admin: boolean;
 }
 
 export interface UpsertOrganizationAction {

--- a/src/store/organizations/types.ts
+++ b/src/store/organizations/types.ts
@@ -1,4 +1,6 @@
 export const UPSERT_ORGANIZATION = "UPSERT_ORGANIZATION";
+export const UPSERT_ORGANIZATIONS = "UPSERT_ORGANIZATIONS";
+export const DELETE_ORGANIZATION = "DELETE_ORGANIZATION";
 export const UPSERT_INVITATION = "UPSERT_INVITATION";
 export const UPSERT_MEMBERSHIP = "UPSERT_MEMBERSHIP";
 
@@ -16,6 +18,11 @@ export interface Organization {
   avatar: string;
 }
 
+export interface OrganizationState {
+  organizations: { [id: number]: Organization };
+  hydrated: boolean;
+}
+
 export interface Invitation {
   organization: number;
   email: string;
@@ -30,3 +37,23 @@ export interface Membership {
   user: number;
   admin: boolean;
 }
+
+export interface UpsertOrganizationAction {
+  type: typeof UPSERT_ORGANIZATION;
+  organization: Organization;
+}
+
+export interface UpsertOrganizationsAction {
+  type: typeof UPSERT_ORGANIZATIONS;
+  organizations: Organization[];
+}
+
+export interface DeleteOrganizationAction {
+  type: typeof DELETE_ORGANIZATION;
+  organization: Organization;
+}
+
+export type OrganizationAction =
+  | UpsertOrganizationAction
+  | UpsertOrganizationsAction
+  | DeleteOrganizationAction;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -95,6 +95,11 @@ export const PATCH = (body?: any): RequestInit => ({
   method: 'PATCH',
   body: body
 });
+export const PUT = (body?: any): RequestInit => ({
+  ...REQ_BASE,
+  method: 'PUT',
+  body: body
+});
 export const JSON_POST = (body?: object): RequestInit => ({
   ...JSON_REQ_BASE,
   method: 'POST',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,13 @@
-import { AppActions } from "../store/";
-import cookie from "js-cookie";
-import { store as notifications } from "react-notifications-component";
+import { AppActions } from '../store/';
+import cookie from 'js-cookie';
+import { store as notifications } from 'react-notifications-component';
 
 export function checkAuth(actions: AppActions) {
   return (response: Response): Response => {
     if (response.status === 403) {
       actions.logout();
-      notify("Please log in to continue.", "success");
-      throw new Error("Not logged in");
+      notify('Please log in to continue.', 'success');
+      throw new Error('Not logged in');
     }
     return response;
   };
@@ -15,11 +15,11 @@ export function checkAuth(actions: AppActions) {
 
 function updateOptions(options: RequestInit) {
   const update = { ...options };
-  console.log(cookie.get("csrftoken"));
-  if (cookie.get("csrftoken") !== undefined) {
+  console.log(cookie.get('csrftoken'));
+  if (cookie.get('csrftoken') !== undefined) {
     update.headers = {
       ...update.headers,
-      "X-CSRFToken": cookie.get("csrftoken") || ""
+      'X-CSRFToken': cookie.get('csrftoken') || ''
     };
   }
   return update;
@@ -30,8 +30,8 @@ function updateOptions(options: RequestInit) {
 export function cfetch(url: string, options: RequestInit) {
   return fetch(url, updateOptions(options)).catch(e => {
     notify(
-      "Unable to connect to the internet. Check your connection and try again.",
-      "danger"
+      'Unable to connect to the internet. Check your connection and try again.',
+      'danger'
     );
     throw e;
   });
@@ -55,7 +55,7 @@ export async function validate(
       ok(itemizedResponse);
     }
   } else {
-    notify("Please fix the errors to continue.", "danger");
+    notify('Please fix the errors to continue.', 'danger');
   }
   return itemizedResponse;
 }
@@ -64,9 +64,9 @@ export function notify(message: string, type: string) {
   notifications.addNotification({
     message,
     type,
-    container: "bottom-right",
-    animationIn: ["animated", "fadeIn"],
-    animationOut: ["animated", "fadeOut"],
+    container: 'bottom-right',
+    animationIn: ['animated', 'fadeIn'],
+    animationOut: ['animated', 'fadeOut'],
     dismiss: {
       duration: 2500
     }
@@ -75,33 +75,33 @@ export function notify(message: string, type: string) {
 
 // For cfetch
 const REQ_BASE: RequestInit = {
-  credentials: "include"
+  credentials: 'include'
 };
 const JSON_REQ_BASE: RequestInit = {
-  credentials: "include",
+  credentials: 'include',
   headers: {
-    "Content-Type": "application/json"
+    'Content-Type': 'application/json'
   }
 };
-export const GET = Object.assign({}, REQ_BASE, { method: "GET" });
-export const DELETE = Object.assign({}, REQ_BASE, { method: "DELETE" });
+export const GET = Object.assign({}, REQ_BASE, { method: 'GET' });
+export const DELETE = Object.assign({}, REQ_BASE, { method: 'DELETE' });
 export const POST = (body?: any): RequestInit => ({
   ...REQ_BASE,
-  method: "POST",
+  method: 'POST',
   body: body
 });
 export const PATCH = (body?: any): RequestInit => ({
   ...REQ_BASE,
-  method: "PATCH",
+  method: 'PATCH',
   body: body
 });
 export const JSON_POST = (body?: object): RequestInit => ({
   ...JSON_REQ_BASE,
-  method: "POST",
+  method: 'POST',
   body: JSON.stringify(body)
 });
 export const JSON_PATCH = (body?: object): RequestInit => ({
   ...JSON_REQ_BASE,
-  method: "PATCH",
+  method: 'PATCH',
   body: JSON.stringify(body)
 });


### PR DESCRIPTION
This is **still** a WIP draft PR but... more progress was made. I think it'll take me a little while to get used to 6:30am meetings (I'll get there). I continued my re-entry to react + redux, and actually got the organizations loading on the profile page!

Status is now:

* profile page now uses a basic bulma layout
* I ended up using a simple table to layout the profile details
* it now includes `email` and links to `change password` and `manage clients`
* organization store scaffolding done
* additional function to grab the list of organizations for a given `uuid`
* organizations you're a member of now display on your profile page
* scaffolding is done for memberships in the store
  * including api calls to get, update and delete memberships
  * I moved the membership type out of `organizations/types.ts` fyi

~Where I got a little stuck was in wiring this all together. I have to give it a rest today (it's after 4pm here now) but will pick it up again tomorrow after our catch up. The page is doing the additional API call successfully, I suspect I'm not mapping the `results` right or that my conditional inclusion of the list in the view is going wrong.  And I might be using things like `useEffect` incorrectly - pretty sure React didn't have this kind of hook function when I last used it.~

^^ I was partially right ^^ In any case the ProfilePage now iterates over organizations and renders an OrganizationCard for each one.

TODO:

* display membership-contextual functionality for each org
* fix up display of org card a bit (it's currently a total copy of the client card)

And also, but I think I'd prefer a new PR for the following to avoid this one getting too big and living on & on:

* Request to join a new organization
* Remove themselves from an organization