### PR TITLE
Removed list of invites from profile

### DIFF
--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -2,10 +2,8 @@ import React, { useEffect } from 'react';
 import { AppActions } from '../store';
 import { Link } from 'react-router-dom';
 import { Membership, MembershipState } from '../store/memberships/types';
-import { Invitation, InvitationState } from '../store/invitations/types';
 import { ensureMembershipsForUser } from '../store/memberships/api';
 import MembershipCard from '../membership/MembershipCard';
-import InvitationList from '../invitation/InvitationList';
 import { UsersState } from '../store/users/types';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 
@@ -13,7 +11,6 @@ interface ProfilePageProps {
   actions: AppActions;
   users: UsersState;
   memberships: MembershipState;
-  invitations: InvitationState;
 }
 
 export const ProfilePage: React.FC<ProfilePageProps> = (
@@ -83,12 +80,6 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
                 )
               )}
             </div>
-
-            <InvitationList
-              actions={props.actions}
-              uuid={props.users.self!.uuid}
-              invitations={props.invitations}
-            />
           </div>
         </div>
       </article>


### PR DESCRIPTION
As per our discussion with MuckRock, I've removed the invite list from the profile page. Note this PR doesn't remove invitations entirely - they still have functionality in the store, as I think we'll need some of it to handle accepting/rejecting invites in the near future. I'll clean that code up once we know what we need exactly.