### PR TITLE
Invitation landing page

### DIFF
--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -36,7 +36,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
       <article className="media profile">
         <figure className="media-left">
           <p className="image is-64x64">
-            <img alt="profile photo" src={avatar} />
+            <img alt="profile" src={avatar} />
           </p>
         </figure>
         <div className="media-content">

--- a/src/entitlements/EntitlementCard.tsx
+++ b/src/entitlements/EntitlementCard.tsx
@@ -10,7 +10,12 @@ const EntitlementCard: React.FC<EntitlementCardProps> = (
 ) => {
   let entitlement = props.entitlement;
   return (
-    <a className="box" target="_blank" href={entitlement.client.website_url}>
+    <a
+      className="box"
+      target="_blank"
+      rel="noopener noreferrer"
+      href={entitlement.client.website_url}
+    >
       <h5 className="title is-size-5">{entitlement.name}</h5>
       <div className="field is-grouped is-grouped-multiline">
         <div className="control">

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { AppActions } from '../store';
 import { Invitation } from '../store/invitations/types';
 import { acceptInvitation, rejectInvitation } from '../store/invitations/api';
-import { Link } from 'react-router-dom';
+import { Redirect } from 'react-router';
 
 interface InvitationCardProps {
   actions: AppActions;
@@ -48,6 +48,10 @@ const InvitationActions: React.FC<InvitationCardProps> = (
       }
     });
   };
+
+  if (saved) {
+    return <Redirect to={`/profile`} />;
+  }
 
   if (showActionButtons) {
     return (

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -89,6 +89,8 @@ const InvitationActions: React.FC<InvitationCardProps> = (
         )}
       </div>
     );
+  } else if (saved) {
+    return <div>All done!</div>;
   } else {
     return <div>Unhandled invitation state.</div>;
   }
@@ -101,7 +103,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
 
   return (
     <div key={invitation.uuid} className="box">
-      <h5 className="title is-size-5">{invitation.organization}</h5>
+      <h5 className="title is-size-5">{invitation.organization.name}</h5>
       <div>
         <InvitationActions actions={props.actions} invitation={invitation} />
         <p>

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -19,19 +19,13 @@ const InvitationActions: React.FC<InvitationCardProps> = (
   let invitation = props.invitation;
 
   // i've been invited, and I can say yes or no
-  let showActionButtons =
-    !accepted &&
-    !rejected &&
-    !invitation.request;
+  let showActionButtons = !accepted && !rejected && !invitation.request;
 
   // I've requested membership and it's pending
-  let showRequestIsPendingStatus =
-    !accepted &&
-    !rejected &&
-    invitation.request;
+  let showRequestIsPendingStatus = !accepted && !rejected && invitation.request;
 
   // I've requested membership and it's either been approved or booed
-  let showInvitationIsHandledStatus = (accepted || rejected)
+  let showInvitationIsHandledStatus = accepted || rejected;
 
   const onAcceptClick = () => {
     acceptInvitation(invitation, props.actions).then(status => {
@@ -107,7 +101,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
 
   return (
     <div key={invitation.uuid} className="box">
-      <h5 className="title is-size-5">{invitation.organization.name}</h5>
+      <h5 className="title is-size-5">{invitation.organization}</h5>
       <div>
         <InvitationActions actions={props.actions} invitation={invitation} />
         <p>

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -107,7 +107,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
 
   return (
     <div key={invitation.uuid} className="box">
-      <h5 className="title is-size-5">{invitation.organization}</h5>
+      <h5 className="title is-size-5">{invitation.organization.name}</h5>
       <div>
         <InvitationActions actions={props.actions} invitation={invitation} />
         <p>

--- a/src/invitation/InvitationList.tsx
+++ b/src/invitation/InvitationList.tsx
@@ -24,7 +24,7 @@ const InvitationList: React.FC<InvitationListProps> = (
       <h1 className="title is-size-3">Your Invitations</h1>
       <div className="columns is-multiline">
         {Object.values(invites).map((invitation: Invitation) => (
-          <div key={invitation.organization} className="column is-4">
+          <div key={invitation.organization.uuid} className="column is-4">
             <InvitationCard actions={props.actions} invitation={invitation} />
           </div>
         ))}

--- a/src/invitation/InvitationPage.tsx
+++ b/src/invitation/InvitationPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { AppActions } from '../store';
-import { Invitation, InvitationState } from '../store/invitations/types';
+import { InvitationState } from '../store/invitations/types';
 import { fetchInvitation } from '../store/invitations/api';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import InvitationCard from './InvitationCard';
@@ -16,7 +16,7 @@ export const InvitationPage: React.FC<InvitationPageProps> = (
 ) => {
   useEffect(() => {
     fetchInvitation(props.actions, props.id);
-  }, [props.actions]);
+  }, [props.actions, props.id]);
 
   if (!props.invitations.hydrated) {
     return <LoadingPlaceholder />;

--- a/src/invitation/InvitationPage.tsx
+++ b/src/invitation/InvitationPage.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { Invitation, InvitationState } from '../store/invitations/types';
+import { fetchInvitation } from '../store/invitations/api';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import InvitationCard from './InvitationCard';
+
+interface InvitationPageProps {
+  actions: AppActions;
+  invitations: InvitationState;
+  id: string;
+}
+
+export const InvitationPage: React.FC<InvitationPageProps> = (
+  props: InvitationPageProps
+) => {
+  useEffect(() => {
+    fetchInvitation(props.actions, props.id);
+  }, [props.actions]);
+
+  if (!props.invitations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  let invitation = props.invitations.invitations[props.id];
+
+  return (
+    <section className="invitation-page">
+      <p className="subtitle">Invitation from: </p>
+      <InvitationCard actions={props.actions} invitation={invitation} />
+    </section>
+  );
+};

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -3,7 +3,6 @@ import { AppActions } from '../store';
 import { Membership } from '../store/memberships/types';
 import { Link } from 'react-router-dom';
 import { deleteMembership } from '../store/memberships/api';
-import { membershipReducers } from '../store/memberships/reducers';
 
 interface MembershipCardProps {
   membership: Membership;

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -5,6 +5,7 @@ import { ProtectedRoute } from '../common/routing';
 import { OrganizationPage } from './OrganizationPage';
 import { ManageOrganizationPage } from './ManageOrganizationPage';
 import { OrganizationsList } from './OrganizationsList';
+import { InvitationPage } from '../invitation/InvitationPage';
 
 export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
@@ -28,6 +29,14 @@ export const getRoutes = (props: AppProps) => {
       path="/organizations/:id/manage"
       render={routeProps => (
         <ManageOrganizationPage {...props} id={routeProps.match.params.id} />
+      )}
+      {...authProps}
+    />,
+    <ProtectedRoute
+      exact
+      path="/organizations/:id/invitation"
+      render={routeProps => (
+        <InvitationPage {...props} id={routeProps.match.params.id} />
       )}
       {...authProps}
     />

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -150,7 +150,7 @@ export const acceptInvitation = (
       validate(response, (status: ItemizedResponse) => {
         actions.upsertInvitation(status.body as Invitation);
         notify(
-          `Successfully accepted user ${invitation.user}'s invitation in organization ${invitation.organization}.`,
+          `Successfully accepted invitation to join organization ${invitation.organization.name}.`,
           'success'
         );
       })
@@ -177,7 +177,7 @@ export const rejectInvitation = (
       validate(response, (status: ItemizedResponse) => {
         actions.upsertInvitation(status.body as Invitation);
         notify(
-          `Successfully rejected user ${invitation.user}'s invitation in organization ${invitation.organization}.`,
+          `Successfully rejected invitation to join organization ${invitation.organization.name}.`,
           'success'
         );
       })

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -24,10 +24,14 @@ const serializeInvitation = (invitation: Invitation) => ({
   // including them in the request would result in a 400 response.
 });
 
-export const fetchInvitation = (actions: AppActions, id: string) =>
-  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${id}`, GET)
+export const fetchInvitation = (actions: AppActions, uuid: string) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${uuid}`, GET)
     .then(checkAuth(actions))
     .then(response => response.json())
+    .then(data => {
+      data.uuid = uuid; // necessary because the API lacks this ID in the response
+      return data;
+    })
     .then(data => Promise.all([actions.upsertInvitation(data)]))
     .catch(error => {
       console.error('API Error fetchInvitation', error, error.code);

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -24,6 +24,15 @@ const serializeInvitation = (invitation: Invitation) => ({
   // including them in the request would result in a 400 response.
 });
 
+export const fetchInvitation = (actions: AppActions, id: string) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${id}`, GET)
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertInvitation(data)]))
+    .catch(error => {
+      console.error('API Error fetchInvitation', error, error.code);
+    });
+
 export const fetchInvitationsForUser = (actions: AppActions, uuid: string) =>
   cfetch(
     `${process.env.REACT_APP_SQUARELET_API_URL}/users/${uuid}/invitations`,

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -25,7 +25,10 @@ const serializeInvitation = (invitation: Invitation) => ({
 });
 
 export const fetchInvitation = (actions: AppActions, uuid: string) =>
-  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${uuid}`, GET)
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${uuid}?expand=organization`,
+    GET
+  )
     .then(checkAuth(actions))
     .then(response => response.json())
     .then(data => {

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -22,7 +22,7 @@ export function invitationReducers(
         hydrated: true
       };
       for (let invitation of action.invitations) {
-        incomingObject.invitations[invitation.organization] = invitation;
+        incomingObject.invitations[invitation.organization.uuid] = invitation;
       }
       return Object.assign({}, state, incomingObject);
     }
@@ -31,7 +31,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      incomingObject.invitations[action.invitation.organization] = action.invitation;
+      incomingObject.invitations[action.invitation.uuid] = action.invitation;
       return Object.assign({}, state, incomingObject);
     }
     case DELETE_INVITATION: {
@@ -39,7 +39,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      delete incomingObject.invitations[action.invitation.organization];
+      delete incomingObject.invitations[action.invitation.organization.uuid];
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -1,10 +1,12 @@
+import { Organization } from '../organizations/types';
+
 export const DELETE_INVITATION = 'DELETE_INVITATION';
 export const UPSERT_INVITATION = 'UPSERT_INVITATION';
 export const UPSERT_INVITATIONS = 'UPSERT_INVITATIONS';
 
 export interface Invitation {
   uuid: number;
-  organization: number;
+  organization: Organization;
   user: number;
   request: boolean;
   created_at: Date;

--- a/src/store/memberships/api.ts
+++ b/src/store/memberships/api.ts
@@ -11,7 +11,6 @@ import {
   DELETE
 } from '../../utils';
 import { Membership, MembershipState } from './types';
-import { OrganizationState, Organization } from '../organizations/types';
 
 const serializeMembership = (membership: Membership) => ({
   user: membership.user,


### PR DESCRIPTION
I had created this branch off of [my previous PR](https://github.com/news-catalyst/presspass-frontend/pull/6) which is why this one looks bigger than it is. So far it's really just [one new commit](https://github.com/news-catalyst/presspass-frontend/commit/ce33ce4ec8beee38f94c77b97f1c705f5370fafc).

This task ended up being confusing for a couple reasons, mainly that I was looking at the API docs for `/pp-api/organizations/{organization_uuid}/invitations/` and working with a very similar URL in the invite emails. The email url turned out to include an **invitation** uuid, and that tripped me up for a bit. 

1. Create an organization in Django admin, then create an invitation (enter any email address, skip the user)
2. Copy the invitation ID
3. Load up http://dev.presspass.com:3000/organizations/3fbd3415-5076-4b4e-9d4f-68d247e42fc0/invitation replacing the ID you just copied
4. Click on accept or reject
5. You should get a notification message and land on your profile page
6. The above should also work if you're logged out, then login with an existing account

Next up (separate PR) will be the flow for invites which require creating a PP account before accepting.