### PR TITLE
Profile layout cleanup

### DIFF
--- a/src/account/ProfileAvatar.tsx
+++ b/src/account/ProfileAvatar.tsx
@@ -9,11 +9,11 @@ const ProfileAvatar: React.FC<ProfileAvatarProps> = (
 ) => {
   if (props.avatar) {
     return (
-      <figure className="media-left">
-        <p className="image is-64x64">
+      <div className="media-left">
+        <figure className="image is-64x64">
           <img alt="profile" src={props.avatar} />
-        </p>
-      </figure>
+        </figure>
+      </div>
     );
   } else {
     return null;

--- a/src/account/ProfileAvatar.tsx
+++ b/src/account/ProfileAvatar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface ProfileAvatarProps {
+  avatar: string;
+}
+
+const ProfileAvatar: React.FC<ProfileAvatarProps> = (
+  props: ProfileAvatarProps
+) => {
+  if (props.avatar) {
+    return (
+      <figure className="media-left">
+        <p className="image is-64x64">
+          <img alt="profile" src={props.avatar} />
+        </p>
+      </figure>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default ProfileAvatar;

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Membership, MembershipState } from '../store/memberships/types';
 import { ensureMembershipsForUser } from '../store/memberships/api';
 import MembershipCard from '../membership/MembershipCard';
+import ProfileAvatar from './ProfileAvatar';
 import { UsersState } from '../store/users/types';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 
@@ -34,11 +35,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
 
     return (
       <article className="media profile">
-        <figure className="media-left">
-          <p className="image is-64x64">
-            <img alt="profile" src={avatar} />
-          </p>
-        </figure>
+        <ProfileAvatar avatar={avatar} />
         <div className="media-content">
           <div className="content">
             <h1 className="title is-size-1">Your Profile</h1>

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -36,7 +36,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
       <article className="media profile">
         <figure className="media-left">
           <p className="image is-64x64">
-            <img alt="profile photo" src={avatar} />
+            <img alt="profile" src={avatar} />
           </p>
         </figure>
         <div className="media-content">

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -34,39 +34,34 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
     let avatar = props.users.self!.avatar;
 
     return (
-      <article className="media profile">
-        <ProfileAvatar avatar={avatar} />
-        <div className="media-content">
-          <div className="content">
-            <h1 className="title is-size-1">Your Profile</h1>
-            <table className="table">
-              <tbody>
-                <tr>
-                  <th>Name:</th>
-                  <td>{name}</td>
-                </tr>
-                <tr>
-                  <th>Username:</th>
-                  <td>{username}</td>
-                </tr>
-                <tr>
-                  <th>Email:</th>
-                  <td>{email}</td>
-                </tr>
-                <tr>
-                  <th>Password:</th>
-                  <td>
-                    <Link
-                      to="/profile/change-password"
-                      className="is-link is-outlined"
-                    >
-                      Change Password
-                    </Link>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+      <div>
+        <div className="section">
+          <div className="card">
+            <div className="card-content">
+              <div className="media">
+                <ProfileAvatar avatar={avatar} />
+                <div className="media-content">
+                  <p className="title is-4">{name}</p>
+                  <p className="subtitle is-6">@{username}</p>
+                </div>
+              </div>
 
+              <div className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </div>
+            </div>
+            <footer className="card-footer">
+              <Link to="/profile/change-password" className="card-footer-item">
+                Change Password
+              </Link>
+              <Link to="/clients/create" className="card-footer-item">
+                Create New Client
+              </Link>
+            </footer>
+          </div>
+        </div>
+        <div className="section">
+          <div className="container">
             <h1 className="title is-size-3">Your Memberships</h1>
             <div className="columns is-multiline">
               {Object.values(props.memberships.memberships).map(
@@ -83,7 +78,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
             </div>
           </div>
         </div>
-      </article>
+      </div>
     );
   }
 };

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -86,9 +86,13 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
   }
 
   // necessary as just linking to /register results in location missing the original return url
+  let returnUrl = '/';
+  if (location.state) {
+    returnUrl = location.state.return;
+  }
   const registerLocation = {
     pathname: '/register',
-    state: { return: location.state.return }
+    state: { return: returnUrl }
   };
   const redirectUrl = location.state ? location.state.return : '/';
 

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -1,10 +1,10 @@
-import React, { useState, SyntheticEvent } from "react";
-import { AppActions } from "../store";
-import { AuthState } from "../store/auth/types";
-import { Redirect, useLocation } from "react-router";
-import { cfetch } from "../utils";
-import Field from "../common/Field";
-import { Link } from "react-router-dom";
+import React, { useState, SyntheticEvent } from 'react';
+import { AppActions } from '../store';
+import { AuthState } from '../store/auth/types';
+import { Redirect, useLocation } from 'react-router';
+import { cfetch } from '../utils';
+import Field from '../common/Field';
+import { Link } from 'react-router-dom';
 
 type LoginFormResponse = {
   non_field_errors: string[];
@@ -39,11 +39,11 @@ class LoginCredentials {
     let postResp = await cfetch(
       `${process.env.REACT_APP_SQUARELET_API_URL}/auth/login/`,
       {
-        method: "POST",
-        credentials: "include",
+        method: 'POST',
+        credentials: 'include',
         body: this.serializeForLoginForm(),
         headers: {
-          "Content-Type": "application/json"
+          'Content-Type': 'application/json'
         }
       }
     );
@@ -56,8 +56,8 @@ class LoginCredentials {
 }
 
 const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
-  let [username, setUsername] = useState("");
-  let [password, setPassword] = useState("");
+  let [username, setUsername] = useState('');
+  let [password, setPassword] = useState('');
 
   let location = useLocation();
 
@@ -85,7 +85,12 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
     );
   }
 
-  const redirectUrl = location.state ? location.state.return : "/";
+  // necessary as just linking to /register results in location missing the original return url
+  const registerLocation = {
+    pathname: '/register',
+    state: { return: location.state.return }
+  };
+  const redirectUrl = location.state ? location.state.return : '/';
 
   return props.auth.loggedIn ? (
     <div className="notification is-success">
@@ -99,7 +104,7 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
       <Field label="Email" errors={[response.username]}>
         <input
           type="email"
-          className={response.username ? "input is-danger" : "input"}
+          className={response.username ? 'input is-danger' : 'input'}
           placeholder="Your email"
           name="username"
           value={username}
@@ -109,7 +114,7 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
       <Field label="Password" errors={[response.password]}>
         <input
           type="password"
-          className={response.password ? "input is-danger" : "input"}
+          className={response.password ? 'input is-danger' : 'input'}
           placeholder="Password"
           name="password"
           value={password}
@@ -123,7 +128,9 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
         reset password
       </Link>
       <hr />
-      <Link to="/register" className="button is-primary is-outlined">Register New Account</Link>
+      <Link to={registerLocation} className="button is-primary is-outlined">
+        Register New Account
+      </Link>
     </form>
   );
 };

--- a/src/auth/RegisterPage.tsx
+++ b/src/auth/RegisterPage.tsx
@@ -1,22 +1,26 @@
-import React, { useState, SyntheticEvent } from "react";
-import { AppActions } from "../store";
-import { registerAccount } from "../store/auth/api";
-import Field from "../common/Field";
-import { Link } from "react-router-dom";
+import React, { useState, SyntheticEvent } from 'react';
+import { AppActions } from '../store';
+import { registerAccount } from '../store/auth/api';
+import Field from '../common/Field';
+import { Link } from 'react-router-dom';
+import { Redirect, useLocation } from 'react-router';
 
 interface AccountEditPageProps {
   actions: AppActions;
+  location?: any;
 }
 
 const RegisterPage: React.FC<AccountEditPageProps> = (
   props: AccountEditPageProps
 ) => {
   let [errors, setErrors] = useState<any>({});
-  let [username, setUsername] = useState("");
-  let [email, setEmail] = useState("");
-  let [password, setPassword] = useState("");
-  let [passwordConfirm, setPasswordConfirm] = useState("");
+  let [username, setUsername] = useState('');
+  let [email, setEmail] = useState('');
+  let [password, setPassword] = useState('');
+  let [passwordConfirm, setPasswordConfirm] = useState('');
   let [saved, setSaved] = useState(false);
+
+  let location = useLocation();
 
   function handleFormSubmit(event: SyntheticEvent) {
     event.preventDefault();
@@ -36,13 +40,17 @@ const RegisterPage: React.FC<AccountEditPageProps> = (
     });
   }
 
+  const redirectUrl = location.state ? location.state.return : '/';
+
   if (saved) {
     return (
       <div className="notification is-success">
-        <strong>Welcome!</strong> Thank you for signing up for PressPass. You will receive an email confirmation
-        email shortly. In the meantime, you can continue to the <Link to="/">homepage</Link>.
+        <strong>Welcome!</strong> Thank you for signing up for PressPass. You
+        will receive an email confirmation email shortly. In the meantime, we'll
+        redirect you or you can continue to the <Link to="/">homepage</Link>.
+        <Redirect to={redirectUrl} />
       </div>
-    )
+    );
   }
 
   return (
@@ -52,7 +60,7 @@ const RegisterPage: React.FC<AccountEditPageProps> = (
         <Field label="Username" errors={errors.username}>
           <input
             type="text"
-            className={errors.username ? "input is-danger" : "input"}
+            className={errors.username ? 'input is-danger' : 'input'}
             value={username}
             onChange={event => setUsername(event.target.value)}
           />
@@ -60,7 +68,7 @@ const RegisterPage: React.FC<AccountEditPageProps> = (
         <Field label="Email" errors={errors.email}>
           <input
             type="email"
-            className={errors.email ? "input is-danger" : "input"}
+            className={errors.email ? 'input is-danger' : 'input'}
             value={email}
             onChange={event => setEmail(event.target.value)}
           />
@@ -68,7 +76,7 @@ const RegisterPage: React.FC<AccountEditPageProps> = (
         <Field label="New Password" errors={errors.password1}>
           <input
             type="password"
-            className={errors.password1 ? "input is-danger" : "input"}
+            className={errors.password1 ? 'input is-danger' : 'input'}
             value={password}
             onChange={event => setPassword(event.target.value)}
           />
@@ -76,7 +84,7 @@ const RegisterPage: React.FC<AccountEditPageProps> = (
         <Field label="Confirm New Password" errors={errors.password2}>
           <input
             type="password"
-            className={errors.password2 ? "input is-danger" : "input"}
+            className={errors.password2 ? 'input is-danger' : 'input'}
             value={passwordConfirm}
             onChange={event => setPasswordConfirm(event.target.value)}
           />

--- a/src/entitlements/EntitlementCard.tsx
+++ b/src/entitlements/EntitlementCard.tsx
@@ -10,7 +10,12 @@ const EntitlementCard: React.FC<EntitlementCardProps> = (
 ) => {
   let entitlement = props.entitlement;
   return (
-    <a className="box" target="_blank" href={entitlement.client.website_url}>
+    <a
+      className="box"
+      target="_blank"
+      rel="noopener noreferrer"
+      href={entitlement.client.website_url}
+    >
       <h5 className="title is-size-5">{entitlement.name}</h5>
       <div className="field is-grouped is-grouped-multiline">
         <div className="control">

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { AppActions } from '../store';
 import { Invitation } from '../store/invitations/types';
 import { acceptInvitation, rejectInvitation } from '../store/invitations/api';
-import { Link } from 'react-router-dom';
+import { Redirect } from 'react-router';
 
 interface InvitationCardProps {
   actions: AppActions;
@@ -48,6 +48,10 @@ const InvitationActions: React.FC<InvitationCardProps> = (
       }
     });
   };
+
+  if (saved) {
+    return <Redirect to={`/profile`} />;
+  }
 
   if (showActionButtons) {
     return (

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -89,6 +89,8 @@ const InvitationActions: React.FC<InvitationCardProps> = (
         )}
       </div>
     );
+  } else if (saved) {
+    return <div>All done!</div>;
   } else {
     return <div>Unhandled invitation state.</div>;
   }
@@ -101,7 +103,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
 
   return (
     <div key={invitation.uuid} className="box">
-      <h5 className="title is-size-5">{invitation.organization}</h5>
+      <h5 className="title is-size-5">{invitation.organization.name}</h5>
       <div>
         <InvitationActions actions={props.actions} invitation={invitation} />
         <p>

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -19,19 +19,13 @@ const InvitationActions: React.FC<InvitationCardProps> = (
   let invitation = props.invitation;
 
   // i've been invited, and I can say yes or no
-  let showActionButtons =
-    !accepted &&
-    !rejected &&
-    !invitation.request;
+  let showActionButtons = !accepted && !rejected && !invitation.request;
 
   // I've requested membership and it's pending
-  let showRequestIsPendingStatus =
-    !accepted &&
-    !rejected &&
-    invitation.request;
+  let showRequestIsPendingStatus = !accepted && !rejected && invitation.request;
 
   // I've requested membership and it's either been approved or booed
-  let showInvitationIsHandledStatus = (accepted || rejected)
+  let showInvitationIsHandledStatus = accepted || rejected;
 
   const onAcceptClick = () => {
     acceptInvitation(invitation, props.actions).then(status => {
@@ -107,7 +101,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
 
   return (
     <div key={invitation.uuid} className="box">
-      <h5 className="title is-size-5">{invitation.organization.name}</h5>
+      <h5 className="title is-size-5">{invitation.organization}</h5>
       <div>
         <InvitationActions actions={props.actions} invitation={invitation} />
         <p>

--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -107,7 +107,7 @@ const InvitationCard: React.FC<InvitationCardProps> = (
 
   return (
     <div key={invitation.uuid} className="box">
-      <h5 className="title is-size-5">{invitation.organization}</h5>
+      <h5 className="title is-size-5">{invitation.organization.name}</h5>
       <div>
         <InvitationActions actions={props.actions} invitation={invitation} />
         <p>

--- a/src/invitation/InvitationList.tsx
+++ b/src/invitation/InvitationList.tsx
@@ -24,7 +24,7 @@ const InvitationList: React.FC<InvitationListProps> = (
       <h1 className="title is-size-3">Your Invitations</h1>
       <div className="columns is-multiline">
         {Object.values(invites).map((invitation: Invitation) => (
-          <div key={invitation.organization} className="column is-4">
+          <div key={invitation.organization.uuid} className="column is-4">
             <InvitationCard actions={props.actions} invitation={invitation} />
           </div>
         ))}

--- a/src/invitation/InvitationPage.tsx
+++ b/src/invitation/InvitationPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { AppActions } from '../store';
-import { Invitation, InvitationState } from '../store/invitations/types';
+import { InvitationState } from '../store/invitations/types';
 import { fetchInvitation } from '../store/invitations/api';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import InvitationCard from './InvitationCard';
@@ -16,7 +16,7 @@ export const InvitationPage: React.FC<InvitationPageProps> = (
 ) => {
   useEffect(() => {
     fetchInvitation(props.actions, props.id);
-  }, [props.actions]);
+  }, [props.actions, props.id]);
 
   if (!props.invitations.hydrated) {
     return <LoadingPlaceholder />;

--- a/src/invitation/InvitationPage.tsx
+++ b/src/invitation/InvitationPage.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { Invitation, InvitationState } from '../store/invitations/types';
+import { fetchInvitation } from '../store/invitations/api';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import InvitationCard from './InvitationCard';
+
+interface InvitationPageProps {
+  actions: AppActions;
+  invitations: InvitationState;
+  id: string;
+}
+
+export const InvitationPage: React.FC<InvitationPageProps> = (
+  props: InvitationPageProps
+) => {
+  useEffect(() => {
+    fetchInvitation(props.actions, props.id);
+  }, [props.actions]);
+
+  if (!props.invitations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  let invitation = props.invitations.invitations[props.id];
+
+  return (
+    <section className="invitation-page">
+      <p className="subtitle">Invitation from: </p>
+      <InvitationCard actions={props.actions} invitation={invitation} />
+    </section>
+  );
+};

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -3,7 +3,6 @@ import { AppActions } from '../store';
 import { Membership } from '../store/memberships/types';
 import { Link } from 'react-router-dom';
 import { deleteMembership } from '../store/memberships/api';
-import { membershipReducers } from '../store/memberships/reducers';
 
 interface MembershipCardProps {
   membership: Membership;

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -37,7 +37,7 @@ const ManageButton: React.FC<ManageButtonProps> = (
   return (
     <Link
       to={'/organizations/' + props.membership.organization.uuid + '/manage'}
-      className="button"
+      className="card-footer-item"
     >
       Manage
     </Link>
@@ -53,20 +53,30 @@ const MembershipCard: React.FC<MembershipCardProps> = (
   };
 
   return (
-    <div className="box">
-      <Link to={'/organizations/' + membership.organization.uuid}>
-        <h5 className="title is-size-5">{membership.organization.name}</h5>
-      </Link>
-      <div className="field is-grouped is-grouped-multiline">
-        <div className="control">
-          <div className="tags has-addons"></div>
+    <div className="card">
+      <header className="card-header">
+        <p className="card-header-title">
+          <Link to={'/organizations/' + membership.organization.uuid}>
+            {membership.organization.name}
+          </Link>
+        </p>
+        <p className="card-header-icon">
+          <span className="icon">
+            <i className="fas fa-angle-down" aria-hidden="true"></i>
+          </span>
+        </p>
+      </header>
+      <div className="card-content">
+        <div className="content">
           <AdminTag isAdmin={membership.admin} />
-          <ManageButton membership={membership} />
-          <button onClick={removeMembership} className="button is-danger">
-            Remove
-          </button>
         </div>
       </div>
+      <footer className="card-footer">
+        <ManageButton membership={membership} />
+        <a onClick={removeMembership} className="card-footer-item">
+          Remove
+        </a>
+      </footer>
     </div>
   );
 };

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -5,6 +5,7 @@ import { ProtectedRoute } from '../common/routing';
 import { OrganizationPage } from './OrganizationPage';
 import { ManageOrganizationPage } from './ManageOrganizationPage';
 import { OrganizationsList } from './OrganizationsList';
+import { InvitationPage } from '../invitation/InvitationPage';
 
 export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
@@ -28,6 +29,14 @@ export const getRoutes = (props: AppProps) => {
       path="/organizations/:id/manage"
       render={routeProps => (
         <ManageOrganizationPage {...props} id={routeProps.match.params.id} />
+      )}
+      {...authProps}
+    />,
+    <ProtectedRoute
+      exact
+      path="/organizations/:id/invitation"
+      render={routeProps => (
+        <InvitationPage {...props} id={routeProps.match.params.id} />
       )}
       {...authProps}
     />

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -150,7 +150,7 @@ export const acceptInvitation = (
       validate(response, (status: ItemizedResponse) => {
         actions.upsertInvitation(status.body as Invitation);
         notify(
-          `Successfully accepted user ${invitation.user}'s invitation in organization ${invitation.organization}.`,
+          `Successfully accepted invitation to join organization ${invitation.organization.name}.`,
           'success'
         );
       })
@@ -177,7 +177,7 @@ export const rejectInvitation = (
       validate(response, (status: ItemizedResponse) => {
         actions.upsertInvitation(status.body as Invitation);
         notify(
-          `Successfully rejected user ${invitation.user}'s invitation in organization ${invitation.organization}.`,
+          `Successfully rejected invitation to join organization ${invitation.organization.name}.`,
           'success'
         );
       })

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -24,10 +24,14 @@ const serializeInvitation = (invitation: Invitation) => ({
   // including them in the request would result in a 400 response.
 });
 
-export const fetchInvitation = (actions: AppActions, id: string) =>
-  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${id}`, GET)
+export const fetchInvitation = (actions: AppActions, uuid: string) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${uuid}`, GET)
     .then(checkAuth(actions))
     .then(response => response.json())
+    .then(data => {
+      data.uuid = uuid; // necessary because the API lacks this ID in the response
+      return data;
+    })
     .then(data => Promise.all([actions.upsertInvitation(data)]))
     .catch(error => {
       console.error('API Error fetchInvitation', error, error.code);

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -24,6 +24,15 @@ const serializeInvitation = (invitation: Invitation) => ({
   // including them in the request would result in a 400 response.
 });
 
+export const fetchInvitation = (actions: AppActions, id: string) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${id}`, GET)
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertInvitation(data)]))
+    .catch(error => {
+      console.error('API Error fetchInvitation', error, error.code);
+    });
+
 export const fetchInvitationsForUser = (actions: AppActions, uuid: string) =>
   cfetch(
     `${process.env.REACT_APP_SQUARELET_API_URL}/users/${uuid}/invitations`,

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -25,7 +25,10 @@ const serializeInvitation = (invitation: Invitation) => ({
 });
 
 export const fetchInvitation = (actions: AppActions, uuid: string) =>
-  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${uuid}`, GET)
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/invitations/${uuid}?expand=organization`,
+    GET
+  )
     .then(checkAuth(actions))
     .then(response => response.json())
     .then(data => {

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -22,7 +22,7 @@ export function invitationReducers(
         hydrated: true
       };
       for (let invitation of action.invitations) {
-        incomingObject.invitations[invitation.organization] = invitation;
+        incomingObject.invitations[invitation.organization.uuid] = invitation;
       }
       return Object.assign({}, state, incomingObject);
     }
@@ -31,7 +31,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      incomingObject.invitations[action.invitation.organization] = action.invitation;
+      incomingObject.invitations[action.invitation.uuid] = action.invitation;
       return Object.assign({}, state, incomingObject);
     }
     case DELETE_INVITATION: {
@@ -39,7 +39,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      delete incomingObject.invitations[action.invitation.organization];
+      delete incomingObject.invitations[action.invitation.organization.uuid];
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -1,10 +1,12 @@
+import { Organization } from '../organizations/types';
+
 export const DELETE_INVITATION = 'DELETE_INVITATION';
 export const UPSERT_INVITATION = 'UPSERT_INVITATION';
 export const UPSERT_INVITATIONS = 'UPSERT_INVITATIONS';
 
 export interface Invitation {
   uuid: number;
-  organization: number;
+  organization: Organization;
   user: number;
   request: boolean;
   created_at: Date;

--- a/src/store/memberships/api.ts
+++ b/src/store/memberships/api.ts
@@ -11,7 +11,6 @@ import {
   DELETE
 } from '../../utils';
 import { Membership, MembershipState } from './types';
-import { OrganizationState, Organization } from '../organizations/types';
 
 const serializeMembership = (membership: Membership) => ({
   user: membership.user,


### PR DESCRIPTION
This PR has a small amount of change:

* the profile photo is moved to its own component, and only rendered if it's present
* the profile info is no longer an ugly table, it's a card
* call to action buttons are at the bottom of the card
* memberships are listed in a separate `<section>`

I'm not sure how we want this page to look in the end so I kept the cleanup fairly minimal; this is just to make the page easier to understand.