### PR TITLE
Admins of organizations now can send invites

### DIFF
--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -57,6 +57,9 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
               <Link to="/clients/create" className="card-footer-item">
                 Create New Client
               </Link>
+              <Link to="/organizations/create" className="card-footer-item">
+                Create New Organization
+              </Link>
             </footer>
           </div>
         </div>

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, SyntheticEvent } from 'react';
 import { AppActions } from '../store';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import Field from '../common/Field';
 import { OrganizationState } from '../store/organizations/types';
 import { ensureOrganizations } from '../store/organizations/api';
+import { createInvitation } from '../store/invitations/api';
+import { Invitation } from '../store/invitations/types';
 
 interface InvitePageProps {
   actions: AppActions;
@@ -13,6 +16,10 @@ interface InvitePageProps {
 export const InvitePage: React.FC<InvitePageProps> = (
   props: InvitePageProps
 ) => {
+  let [errors, setErrors] = useState<any>({});
+  let [saved, setSaved] = useState(false);
+  let [email, setEmail] = useState('');
+
   useEffect(() => {
     ensureOrganizations(props.actions, props.organizations);
   }, [props.actions, props.organizations]);
@@ -20,11 +27,48 @@ export const InvitePage: React.FC<InvitePageProps> = (
   if (!props.organizations.hydrated) {
     return <LoadingPlaceholder />;
   }
+
+  // the list of orgs in the props is filled in by ensureOrganizations
+  // the following line pulls the org out of the map by matching the prop 'organization' (an ID)
   let organization = props.organizations.organizations[props.organization];
-  // let [email, setEmail] = useState('');
+
+  function handleFormSubmit(event: SyntheticEvent) {
+    event.preventDefault();
+
+    createInvitation(organization.uuid, email, props.actions).then(status => {
+      if (status.ok) {
+        setSaved(true);
+        setErrors({});
+      } else {
+        setErrors(status.body);
+      }
+    });
+  }
+
+  if (saved) {
+    return (
+      <div className="notification is-success">
+        <strong>Success!</strong> You've invited TK to the org TKTK.
+      </div>
+    );
+  }
+
   return (
     <div>
       Invite page for organization <b>{organization.name}</b>
+      <form className="limited-width" onSubmit={handleFormSubmit}>
+        <Field label="Email" errors={errors.email}>
+          <input
+            type="email"
+            className={errors.email ? 'input is-danger' : 'input'}
+            value={email}
+            onChange={event => setEmail(event.target.value)}
+          />
+        </Field>
+        <button className="button is-primary" type="submit">
+          Send Invitations
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -48,7 +48,8 @@ export const InvitePage: React.FC<InvitePageProps> = (
   if (saved) {
     return (
       <div className="notification is-success">
-        <strong>Success!</strong> You've invited TK to the org TKTK.
+        <strong>Success!</strong> You've invited {email} to the org{' '}
+        {organization.name}.
       </div>
     );
   }

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -5,6 +5,7 @@ import Field from '../common/Field';
 import { OrganizationState } from '../store/organizations/types';
 import { ensureOrganizations } from '../store/organizations/api';
 import { createInvitation } from '../store/invitations/api';
+import { Link } from 'react-router-dom';
 import { Invitation } from '../store/invitations/types';
 
 interface InvitePageProps {
@@ -50,6 +51,9 @@ export const InvitePage: React.FC<InvitePageProps> = (
       <div className="notification is-success">
         <strong>Success!</strong> You've invited {email} to the org{' '}
         {organization.name}.
+        <p>
+          <Link to="/profile">Return to your profile</Link>.
+        </p>
       </div>
     );
   }

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { AppActions } from '../store';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { OrganizationState } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
+
+interface InvitePageProps {
+  actions: AppActions;
+  organization: number;
+  organizations: OrganizationState;
+}
+
+export const InvitePage: React.FC<InvitePageProps> = (
+  props: InvitePageProps
+) => {
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+  let organization = props.organizations.organizations[props.organization];
+  // let [email, setEmail] = useState('');
+  return (
+    <div>
+      Invite page for organization <b>{organization.name}</b>
+    </div>
+  );
+};

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -13,16 +13,15 @@ interface AdminTagProps {
   isAdmin: boolean;
 }
 const AdminTag: React.FC<AdminTagProps> = (props: AdminTagProps) => {
-  return (
-    <div className="tags has-addons">
-      <span className="tag">Admin?</span>
-      {props.isAdmin ? (
-        <span className="tag is-success">Yes</span>
-      ) : (
-        <span className="tag is-danger">No</span>
-      )}
-    </div>
-  );
+  if (props.isAdmin) {
+    return (
+      <div className="tags has-addons">
+        <span className="tag is-success">Admin</span>
+      </div>
+    );
+  } else {
+    return null;
+  }
 };
 
 interface ManageButtonProps {
@@ -61,14 +60,12 @@ const MembershipCard: React.FC<MembershipCardProps> = (
           </Link>
         </p>
         <p className="card-header-icon">
-          <span className="icon">
-            <i className="fas fa-angle-down" aria-hidden="true"></i>
-          </span>
+          <AdminTag isAdmin={membership.admin} />
         </p>
       </header>
       <div className="card-content">
         <div className="content">
-          <AdminTag isAdmin={membership.admin} />
+          Lorem ipsum about the org, maybe a link, not sure what might go here.
         </div>
       </div>
       <footer className="card-footer">

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -24,6 +24,25 @@ const AdminTag: React.FC<AdminTagProps> = (props: AdminTagProps) => {
   }
 };
 
+interface InviteButtonProps {
+  membership: Membership;
+}
+const InviteButton: React.FC<InviteButtonProps> = (
+  props: InviteButtonProps
+) => {
+  if (!props.membership.admin) {
+    return null;
+  }
+  return (
+    <Link
+      to={'/organizations/' + props.membership.organization.uuid + '/invite'}
+      className="card-footer-item"
+    >
+      Invite
+    </Link>
+  );
+};
+
 interface ManageButtonProps {
   membership: Membership;
 }
@@ -70,6 +89,7 @@ const MembershipCard: React.FC<MembershipCardProps> = (
       </div>
       <footer className="card-footer">
         <ManageButton membership={membership} />
+        <InviteButton membership={membership} />
         <a onClick={removeMembership} className="card-footer-item">
           Remove
         </a>

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -83,9 +83,7 @@ const MembershipCard: React.FC<MembershipCardProps> = (
         </p>
       </header>
       <div className="card-content">
-        <div className="content">
-          Lorem ipsum about the org, maybe a link, not sure what might go here.
-        </div>
+        <div className="content">TK Members, TK Subscriptions</div>
       </div>
       <footer className="card-footer">
         <ManageButton membership={membership} />

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -6,6 +6,7 @@ import { OrganizationPage } from './OrganizationPage';
 import { ManageOrganizationPage } from './ManageOrganizationPage';
 import { OrganizationsList } from './OrganizationsList';
 import { InvitationPage } from '../invitation/InvitationPage';
+import { InvitePage } from '../invitation/InvitePage';
 
 export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
@@ -37,6 +38,14 @@ export const getRoutes = (props: AppProps) => {
       path="/organizations/:id/invitation"
       render={routeProps => (
         <InvitationPage {...props} id={routeProps.match.params.id} />
+      )}
+      {...authProps}
+    />,
+    <ProtectedRoute
+      exact
+      path="/organizations/:id/invite"
+      render={routeProps => (
+        <InvitePage {...props} organization={routeProps.match.params.id} />
       )}
       {...authProps}
     />

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -204,9 +204,13 @@ export const createInvitation = (
   )
     .then(checkAuth(actions)) // Necessary
     .then(response =>
-      validate(response, () =>
-        notify('Successfully sent the invitation.', 'success')
-      )
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertInvitation(status.body as Invitation);
+        notify(
+          '[TODO remove this?] Successfully sent the invitation.',
+          'success'
+        );
+      })
     );
 
 export const deleteInvitation = (invitation: Invitation, actions: AppActions) =>

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -7,7 +7,7 @@ import {
   notify,
   GET,
   PATCH,
-  PUT,
+  JSON_POST,
   DELETE
 } from '../../utils';
 import { Invitation, InvitationState } from './types';
@@ -192,32 +192,22 @@ export const rejectInvitation = (
 };
 
 export const createInvitation = (
-  invitation: Invitation,
+  organization_id: string,
+  email: string,
   actions: AppActions
-) => {
-  let formData = new FormData();
-  let packagedInvitation: any = serializeInvitation(invitation);
-  for (let key of Object.keys(packagedInvitation)) {
-    formData.append(key, packagedInvitation[key]);
-  }
-  return (
-    cfetch(
-      `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${invitation.organization}/invitations/${invitation.user}`,
-      PUT(formData)
-    )
-      .then(checkAuth(actions))
-      // Cannot call upsert invitation here, because IDs are assigned on the server side
-      .then(response =>
-        validate(response, (status: ItemizedResponse) => {
-          actions.upsertInvitation(status.body as Invitation);
-          notify(
-            `Successfully created invitation for user ${invitation.user} in organization ${invitation.organization}.`,
-            'success'
-          );
-        })
+) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization_id}/invitations/`,
+    JSON_POST({
+      email: email
+    })
+  )
+    .then(checkAuth(actions)) // Necessary
+    .then(response =>
+      validate(response, () =>
+        notify('Successfully sent the invitation.', 'success')
       )
-  );
-};
+    );
 
 export const deleteInvitation = (invitation: Invitation, actions: AppActions) =>
   cfetch(

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -8,6 +8,7 @@ export interface Invitation {
   uuid: number;
   organization: Organization;
   user: number;
+  email: string;
   request: boolean;
   created_at: Date;
   accepted_at: Date;


### PR DESCRIPTION
This PR adds an "Invite" button to the `MembershipCard` for logged in users who are admins of the organization. Clicking "Invite" brings you to a new page where you enter an email address, click a button, and (hopefully) get a success message.

Note: there is a brief success notification in addition to the static success message. I think we need to figure out these notice messages throughout the site though...

Question: should we add a link back to the profile page, or perhaps redirect back there? I wasn't sure.

Rather than make another PR building on top of this branch's work, I also snuck in an extra button on the profile page to "Create New Organization" that currently goes to a placeholder page.