### PR TITLE
Create an organization functionality

### DIFF
--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -66,6 +66,8 @@ const MembershipCard: React.FC<MembershipCardProps> = (
   props: MembershipCardProps
 ) => {
   let membership = props.membership;
+  let organization = membership.organization;
+
   const removeMembership = () => {
     deleteMembership(membership, props.actions);
   };
@@ -74,17 +76,24 @@ const MembershipCard: React.FC<MembershipCardProps> = (
     <div className="card">
       <header className="card-header">
         <p className="card-header-title">
-          <Link to={'/organizations/' + membership.organization.uuid}>
-            {membership.organization.name}
+          <Link to={'/organizations/' + organization.uuid}>
+            {organization.name}
           </Link>
         </p>
-        <p className="card-header-icon">
+        <div className="card-header-icon">
           <AdminTag isAdmin={membership.admin} />
-        </p>
+        </div>
       </header>
+
       <div className="card-content">
         <div className="content">
-          Lorem ipsum about the org, maybe a link, not sure what might go here.
+          <div className="media-content">
+            <div className="content">
+              <p>{membership.organization.avatar}</p>
+              Lorem ipsum about the org, maybe a link, not sure what might go
+              here.
+            </div>
+          </div>
         </div>
       </div>
       <footer className="card-footer">

--- a/src/organization/ManageOrganizationPage.tsx
+++ b/src/organization/ManageOrganizationPage.tsx
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { OrganizationState, Organization } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { AppProps } from '../store';
 import { Link } from 'react-router-dom';
 
 interface ManageOrganizationPageProps extends AppProps {
-  id: string;
+  organization: string;
+  organizations: OrganizationState;
+  actions: AppActions;
 }
 
 export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  let organization = props.organizations.organizations[props.organization];
   return (
-    <p>Manage organization page (id {props.id}) (<Link to=".">view</Link>)</p>
-  )
-}
+    <section className="organization-page">
+      <p className="subtitle">Manage PressPass News Organization</p>
+      <h1 className="title is-size-1">{organization.name}</h1>
+      <p>
+        Manage organization page (id {organization.uuid}) (
+        <Link to=".">view</Link>)
+      </p>
+    </section>
+  );
+};

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { AppActions } from '../store';
+import { Organization } from '../store/organizations/types';
+import { createOrganization } from '../store/organizations/api';
+import OrganizationForm from './OrganizationForm';
+import { Redirect } from 'react-router';
+
+interface OrganizationCreatePageProps {
+  actions: AppActions;
+}
+
+export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
+  props: OrganizationCreatePageProps
+) => {
+  let organization: Organization = {
+    name: '',
+    plan: 'free',
+    private: false,
+    individual: false,
+    payment_failed: false,
+    avatar: '',
+    max_users: 0,
+    slug: '',
+    update_on: new Date(),
+    updated_at: new Date(),
+    uuid: ''
+  };
+  // Saved is -1 if the org is not saved, and is the id
+  // of the created org if it has been created.
+  let [saved, setSaved] = useState(-1);
+  let [errors, setErrors] = useState({});
+
+  const handleSubmit = (updatedOrganization: Organization) => {
+    createOrganization(updatedOrganization, props.actions).then(status => {
+      if (status.ok) {
+        setSaved(status.body.uuid);
+      } else {
+        setErrors(status.body);
+      }
+    });
+  };
+
+  if (saved !== -1) {
+    return <Redirect to={`/organizations/${saved}`} />;
+  } else {
+    return (
+      <section className="organization-page">
+        <h1 className="title is-size-1">New Organization</h1>
+        <OrganizationForm
+          organization={organization}
+          onSubmit={handleSubmit}
+          errors={errors}
+        />
+        <br />
+      </section>
+    );
+  }
+};

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -1,0 +1,89 @@
+// Form separated from page so that it can DRY-ly be used in both
+// the 'create' component and the 'edit' component.
+
+import React, { useState, SyntheticEvent } from 'react';
+import { Organization } from '../store/organizations/types';
+import Field from '../common/Field';
+
+interface OrganizationFormProps {
+  organization: Organization;
+  onSubmit: (parameter: Organization) => void;
+  errors: any;
+}
+
+const OrganizationForm: React.FC<OrganizationFormProps> = (
+  props: OrganizationFormProps
+) => {
+  let organization = props.organization;
+
+  let [name, setName] = useState(organization.name);
+  let [plan, setPlan] = useState(organization.plan);
+  let [privateOrg, setPrivateOrg] = useState(organization.private);
+  // let [avatar, setAvatar] = useState(organization.avatar);
+  // let [avatar, setAvatar] = useState<File | undefined>(undefined);
+
+  let newOrganization: Organization = {
+    ...organization,
+    name: name,
+    plan: plan,
+    private: privateOrg
+  };
+
+  let errors = props.errors;
+
+  const handleSubmit = (event: SyntheticEvent) => {
+    event.preventDefault();
+    console.log(newOrganization);
+    props.onSubmit(newOrganization);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="limited-width">
+      <Field label="Name" errors={errors.name}>
+        <input
+          className={errors.name ? 'input is-danger' : 'input'}
+          type="text"
+          placeholder="Your organization's name..."
+          value={name}
+          onChange={event => setName(event.target.value)}
+        />
+      </Field>
+      <Field
+        label="Plan"
+        errors={errors.plan}
+        help="The current plan this organization is subscribed to"
+      >
+        <div className={errors.plan ? 'select is-danger' : 'select'}>
+          <select value={plan} onChange={event => setPlan(event.target.value)}>
+            <option value="admin">Admin</option>
+            <option value="beta">Beta</option>
+            <option value="free">Free</option>
+            <option value="manual-pay-organization">
+              Manual Pay Organization
+            </option>
+            <option value="organization">Organization</option>
+            <option value="organization-plus">Organization Plus</option>
+            <option value="professional">Professional</option>
+            <option value="proxy">Proxy</option>
+          </select>
+        </div>
+      </Field>
+      <Field errors={errors.private}>
+        <label className={errors.private ? 'checkbox is-danger' : 'checkbox'}>
+          <input
+            type="checkbox"
+            checked={privateOrg}
+            onChange={event => setPrivateOrg(event.target.checked)}
+          />
+          This organization's information and membership is not made public
+        </label>
+      </Field>
+      <br />
+      <button type="submit" className="button is-link">
+        Save
+      </button>
+    </form>
+  );
+};
+
+export default OrganizationForm;

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -19,21 +19,20 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let [name, setName] = useState(organization.name);
   let [plan, setPlan] = useState(organization.plan);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
-  // let [avatar, setAvatar] = useState(organization.avatar);
-  // let [avatar, setAvatar] = useState<File | undefined>(undefined);
+  let [avatar, setAvatar] = useState<File | undefined>(undefined);
 
   let newOrganization: Organization = {
     ...organization,
     name: name,
     plan: plan,
-    private: privateOrg
+    private: privateOrg,
+    avatar: avatar
   };
 
   let errors = props.errors;
 
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
-    console.log(newOrganization);
     props.onSubmit(newOrganization);
   };
 
@@ -49,24 +48,20 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
         />
       </Field>
       <Field
-        label="Plan"
-        errors={errors.plan}
-        help="The current plan this organization is subscribed to"
+        label="Avatar"
+        errors={errors.avatar}
+        help="If you do not upload a file, the current photo will be kept."
       >
-        <div className={errors.plan ? 'select is-danger' : 'select'}>
-          <select value={plan} onChange={event => setPlan(event.target.value)}>
-            <option value="admin">Admin</option>
-            <option value="beta">Beta</option>
-            <option value="free">Free</option>
-            <option value="manual-pay-organization">
-              Manual Pay Organization
-            </option>
-            <option value="organization">Organization</option>
-            <option value="organization-plus">Organization Plus</option>
-            <option value="professional">Professional</option>
-            <option value="proxy">Proxy</option>
-          </select>
-        </div>
+        <input
+          className={errors.avatar ? 'input is-danger' : 'input'}
+          type="file"
+          placeholder="Your organization's logo..."
+          onChange={event =>
+            setAvatar(
+              event.target.files === null ? undefined : event.target.files[0]
+            )
+          }
+        />
       </Field>
       <Field errors={errors.private}>
         <label className={errors.private ? 'checkbox is-danger' : 'checkbox'}>

--- a/src/organization/OrganizationPage.tsx
+++ b/src/organization/OrganizationPage.tsx
@@ -1,13 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { OrganizationState, Organization } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
 import { AppProps } from '../store';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { Link } from 'react-router-dom';
 
 interface OrganizationPageProps extends AppProps {
-  id: string;
+  organization: string;
+  organizations: OrganizationState;
+  actions: AppActions;
 }
 
 export const OrganizationPage = (props: OrganizationPageProps) => {
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  let organization = props.organizations.organizations[props.organization];
   return (
-    <p>Organization page (id {props.id}) (<Link to={`./${props.id}/manage`}>manage</Link>)</p>
-  )
-}
+    <section className="organization-page">
+      <p className="subtitle">PressPass News Organization</p>
+      <h1 className="title is-size-1">{organization.name}</h1>
+      <table className="table">
+        <tbody>
+          <tr>
+            <td className="has-text-weight-bold">Name</td>
+            <td>{organization.name}</td>
+          </tr>
+          <tr>
+            <td className="has-text-weight-bold">Avatar</td>
+            <td>{organization.avatar}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Organization page (id {organization.uuid}) (
+        <Link to={`./${organization.id}/manage`}>manage</Link>)
+      </p>
+    </section>
+  );
+};

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -28,7 +28,10 @@ export const getRoutes = (props: AppProps) => {
       exact
       path="/organizations/:id"
       render={routeProps => (
-        <OrganizationPage {...props} id={routeProps.match.params.id} />
+        <OrganizationPage
+          {...props}
+          organization={routeProps.match.params.id}
+        />
       )}
       {...authProps}
     />,
@@ -36,7 +39,10 @@ export const getRoutes = (props: AppProps) => {
       exact
       path="/organizations/:id/manage"
       render={routeProps => (
-        <ManageOrganizationPage {...props} id={routeProps.match.params.id} />
+        <ManageOrganizationPage
+          {...props}
+          organization={routeProps.match.params.id}
+        />
       )}
       {...authProps}
     />,

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -5,6 +5,7 @@ import { ProtectedRoute } from '../common/routing';
 import { OrganizationPage } from './OrganizationPage';
 import { ManageOrganizationPage } from './ManageOrganizationPage';
 import { OrganizationsList } from './OrganizationsList';
+import { OrganizationCreatePage } from './OrganizationCreatePage';
 import { InvitationPage } from '../invitation/InvitationPage';
 import { InvitePage } from '../invitation/InvitePage';
 
@@ -17,6 +18,12 @@ export const getRoutes = (props: AppProps) => {
         organizations={props.organizations}
       />
     </ProtectedRoute>,
+    <ProtectedRoute
+      exact
+      path="/organizations/create"
+      render={routeProps => <OrganizationCreatePage {...props} />}
+      {...authProps}
+    />,
     <ProtectedRoute
       exact
       path="/organizations/:id"

--- a/src/store/organizations/types.ts
+++ b/src/store/organizations/types.ts
@@ -13,7 +13,7 @@ export interface Organization {
   update_on: Date;
   updated_at: Date;
   payment_failed: boolean;
-  avatar: string;
+  avatar?: string | File;
 }
 
 export interface OrganizationState {


### PR DESCRIPTION
This PR adds "create an organization" functionality to PressPass and satisfies [Issue #12](https://github.com/news-catalyst/presspass-frontend/issues/12).

Creating an org allows specifying:

* the name
* avatar (file upload)
* if the org is private (checkbox)

This PR also includes some basic updates to the organization page and manage organization pages.