### PR TITLE
Manage subscriptions to free plans

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import * as organizationActions from './store/organizations/actions';
 import * as invitationActions from './store/invitations/actions';
 import * as membershipActions from './store/memberships/actions';
 import * as planActions from './store/plans/actions';
+import * as subscriptionActions from './store/subscriptions/actions';
 import * as userActions from './store/users/actions';
 import { AuthProps } from './store/auth/types';
 import { forceCheckAuth } from './store/auth/api';
@@ -89,6 +90,7 @@ const mapStateToProps = (state: State) => ({
   invitations: state.invitations,
   organizations: state.organizations,
   plans: state.plans,
+  subscriptions: state.subscriptions,
   users: state.users
 });
 
@@ -104,6 +106,7 @@ const mapDispatchToProps = (dispatch: any) => ({
       invitationActions,
       organizationActions,
       planActions,
+      subscriptionActions,
       userActions
     ),
     dispatch

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import * as entitlementActions from './store/entitlements/actions';
 import * as organizationActions from './store/organizations/actions';
 import * as invitationActions from './store/invitations/actions';
 import * as membershipActions from './store/memberships/actions';
+import * as planActions from './store/plans/actions';
 import * as userActions from './store/users/actions';
 import { AuthProps } from './store/auth/types';
 import { forceCheckAuth } from './store/auth/api';
@@ -87,6 +88,7 @@ const mapStateToProps = (state: State) => ({
   memberships: state.memberships,
   invitations: state.invitations,
   organizations: state.organizations,
+  plans: state.plans,
   users: state.users
 });
 
@@ -101,6 +103,7 @@ const mapDispatchToProps = (dispatch: any) => ({
       membershipActions,
       invitationActions,
       organizationActions,
+      planActions,
       userActions
     ),
     dispatch

--- a/src/account/ProfilePage.tsx
+++ b/src/account/ProfilePage.tsx
@@ -57,6 +57,9 @@ export const ProfilePage: React.FC<ProfilePageProps> = (
               <Link to="/clients/create" className="card-footer-item">
                 Create New Client
               </Link>
+              <Link to="/organizations/create" className="card-footer-item">
+                Create New Organization
+              </Link>
             </footer>
           </div>
         </div>

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, SyntheticEvent } from 'react';
 import { AppActions } from '../store';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import Field from '../common/Field';
 import { OrganizationState } from '../store/organizations/types';
 import { ensureOrganizations } from '../store/organizations/api';
+import { createInvitation } from '../store/invitations/api';
+import { Invitation } from '../store/invitations/types';
 
 interface InvitePageProps {
   actions: AppActions;
@@ -13,6 +16,10 @@ interface InvitePageProps {
 export const InvitePage: React.FC<InvitePageProps> = (
   props: InvitePageProps
 ) => {
+  let [errors, setErrors] = useState<any>({});
+  let [saved, setSaved] = useState(false);
+  let [email, setEmail] = useState('');
+
   useEffect(() => {
     ensureOrganizations(props.actions, props.organizations);
   }, [props.actions, props.organizations]);
@@ -20,11 +27,48 @@ export const InvitePage: React.FC<InvitePageProps> = (
   if (!props.organizations.hydrated) {
     return <LoadingPlaceholder />;
   }
+
+  // the list of orgs in the props is filled in by ensureOrganizations
+  // the following line pulls the org out of the map by matching the prop 'organization' (an ID)
   let organization = props.organizations.organizations[props.organization];
-  // let [email, setEmail] = useState('');
+
+  function handleFormSubmit(event: SyntheticEvent) {
+    event.preventDefault();
+
+    createInvitation(organization.uuid, email, props.actions).then(status => {
+      if (status.ok) {
+        setSaved(true);
+        setErrors({});
+      } else {
+        setErrors(status.body);
+      }
+    });
+  }
+
+  if (saved) {
+    return (
+      <div className="notification is-success">
+        <strong>Success!</strong> You've invited TK to the org TKTK.
+      </div>
+    );
+  }
+
   return (
     <div>
       Invite page for organization <b>{organization.name}</b>
+      <form className="limited-width" onSubmit={handleFormSubmit}>
+        <Field label="Email" errors={errors.email}>
+          <input
+            type="email"
+            className={errors.email ? 'input is-danger' : 'input'}
+            value={email}
+            onChange={event => setEmail(event.target.value)}
+          />
+        </Field>
+        <button className="button is-primary" type="submit">
+          Send Invitations
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -48,7 +48,8 @@ export const InvitePage: React.FC<InvitePageProps> = (
   if (saved) {
     return (
       <div className="notification is-success">
-        <strong>Success!</strong> You've invited TK to the org TKTK.
+        <strong>Success!</strong> You've invited {email} to the org{' '}
+        {organization.name}.
       </div>
     );
   }

--- a/src/invitation/InvitePage.tsx
+++ b/src/invitation/InvitePage.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { AppActions } from '../store';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { OrganizationState } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
+
+interface InvitePageProps {
+  actions: AppActions;
+  organization: number;
+  organizations: OrganizationState;
+}
+
+export const InvitePage: React.FC<InvitePageProps> = (
+  props: InvitePageProps
+) => {
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+  let organization = props.organizations.organizations[props.organization];
+  // let [email, setEmail] = useState('');
+  return (
+    <div>
+      Invite page for organization <b>{organization.name}</b>
+    </div>
+  );
+};

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -66,6 +66,8 @@ const MembershipCard: React.FC<MembershipCardProps> = (
   props: MembershipCardProps
 ) => {
   let membership = props.membership;
+  let organization = membership.organization;
+
   const removeMembership = () => {
     deleteMembership(membership, props.actions);
   };
@@ -74,17 +76,24 @@ const MembershipCard: React.FC<MembershipCardProps> = (
     <div className="card">
       <header className="card-header">
         <p className="card-header-title">
-          <Link to={'/organizations/' + membership.organization.uuid}>
-            {membership.organization.name}
+          <Link to={'/organizations/' + organization.uuid}>
+            {organization.name}
           </Link>
         </p>
-        <p className="card-header-icon">
+        <div className="card-header-icon">
           <AdminTag isAdmin={membership.admin} />
-        </p>
+        </div>
       </header>
+
       <div className="card-content">
         <div className="content">
-          Lorem ipsum about the org, maybe a link, not sure what might go here.
+          <div className="media-content">
+            <div className="content">
+              <p>{membership.organization.avatar}</p>
+              Lorem ipsum about the org, maybe a link, not sure what might go
+              here.
+            </div>
+          </div>
         </div>
       </div>
       <footer className="card-footer">

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -13,16 +13,15 @@ interface AdminTagProps {
   isAdmin: boolean;
 }
 const AdminTag: React.FC<AdminTagProps> = (props: AdminTagProps) => {
-  return (
-    <div className="tags has-addons">
-      <span className="tag">Admin?</span>
-      {props.isAdmin ? (
-        <span className="tag is-success">Yes</span>
-      ) : (
-        <span className="tag is-danger">No</span>
-      )}
-    </div>
-  );
+  if (props.isAdmin) {
+    return (
+      <div className="tags has-addons">
+        <span className="tag is-success">Admin</span>
+      </div>
+    );
+  } else {
+    return null;
+  }
 };
 
 interface ManageButtonProps {
@@ -61,14 +60,12 @@ const MembershipCard: React.FC<MembershipCardProps> = (
           </Link>
         </p>
         <p className="card-header-icon">
-          <span className="icon">
-            <i className="fas fa-angle-down" aria-hidden="true"></i>
-          </span>
+          <AdminTag isAdmin={membership.admin} />
         </p>
       </header>
       <div className="card-content">
         <div className="content">
-          <AdminTag isAdmin={membership.admin} />
+          Lorem ipsum about the org, maybe a link, not sure what might go here.
         </div>
       </div>
       <footer className="card-footer">

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -24,6 +24,25 @@ const AdminTag: React.FC<AdminTagProps> = (props: AdminTagProps) => {
   }
 };
 
+interface InviteButtonProps {
+  membership: Membership;
+}
+const InviteButton: React.FC<InviteButtonProps> = (
+  props: InviteButtonProps
+) => {
+  if (!props.membership.admin) {
+    return null;
+  }
+  return (
+    <Link
+      to={'/organizations/' + props.membership.organization.uuid + '/invite'}
+      className="card-footer-item"
+    >
+      Invite
+    </Link>
+  );
+};
+
 interface ManageButtonProps {
   membership: Membership;
 }
@@ -70,6 +89,7 @@ const MembershipCard: React.FC<MembershipCardProps> = (
       </div>
       <footer className="card-footer">
         <ManageButton membership={membership} />
+        <InviteButton membership={membership} />
         <a onClick={removeMembership} className="card-footer-item">
           Remove
         </a>

--- a/src/organization/ManageOrganizationPage.tsx
+++ b/src/organization/ManageOrganizationPage.tsx
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { OrganizationState, Organization } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { AppProps } from '../store';
 import { Link } from 'react-router-dom';
 
 interface ManageOrganizationPageProps extends AppProps {
-  id: string;
+  organization: string;
+  organizations: OrganizationState;
+  actions: AppActions;
 }
 
 export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  let organization = props.organizations.organizations[props.organization];
   return (
-    <p>Manage organization page (id {props.id}) (<Link to=".">view</Link>)</p>
-  )
-}
+    <section className="organization-page">
+      <p className="subtitle">Manage PressPass News Organization</p>
+      <h1 className="title is-size-1">{organization.name}</h1>
+      <p>
+        Manage organization page (id {organization.uuid}) (
+        <Link to=".">view</Link>)
+      </p>
+    </section>
+  );
+};

--- a/src/organization/ManageOrganizationPage.tsx
+++ b/src/organization/ManageOrganizationPage.tsx
@@ -11,24 +11,42 @@ import { AppProps } from '../store';
 import { Link, Redirect } from 'react-router-dom';
 import { ensurePlans } from '../store/plans/api';
 import OrganizationForm from './OrganizationForm';
+import { ensureSubscriptionsForOrganization } from '../store/subscriptions/api';
+import { SubscriptionState } from '../store/subscriptions/types';
 
 interface ManageOrganizationPageProps extends AppProps {
   actions: AppActions;
   organization: string;
   organizations: OrganizationState;
   plans: PlanState;
+  subscriptions: SubscriptionState;
 }
 
 export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
   useEffect(() => {
-    ensureOrganizations(props.actions, props.organizations);
-    ensurePlans(props.actions, props.plans);
-  }, [props.actions, props.organizations, props.plans]);
+    async function fetchData() {
+      const organizations = await ensureOrganizations(
+        props.actions,
+        props.organizations
+      );
+      const plans = await ensurePlans(props.actions, props.plans);
+      const subscriptions = await ensureSubscriptionsForOrganization(
+        props.actions,
+        props.organization,
+        props.subscriptions
+      );
+    }
+    fetchData();
+  }, []);
 
   let [saved, setSaved] = useState(false);
   let [errors, setErrors] = useState({});
 
-  if (!props.organizations.hydrated || !props.plans.hydrated) {
+  if (
+    !props.organizations.hydrated ||
+    !props.plans.hydrated ||
+    !props.subscriptions.hydrated
+  ) {
     return <LoadingPlaceholder />;
   }
 
@@ -54,6 +72,7 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
         <OrganizationForm
           organization={organization}
           plans={props.plans}
+          subscriptions={props.subscriptions}
           onSubmit={handleSubmit}
           errors={errors}
         />

--- a/src/organization/ManageOrganizationPage.tsx
+++ b/src/organization/ManageOrganizationPage.tsx
@@ -12,7 +12,7 @@ import { Link, Redirect } from 'react-router-dom';
 import { ensurePlans } from '../store/plans/api';
 import OrganizationForm from './OrganizationForm';
 import { ensureSubscriptionsForOrganization } from '../store/subscriptions/api';
-import { SubscriptionState } from '../store/subscriptions/types';
+import { SubscriptionState, Subscription } from '../store/subscriptions/types';
 
 interface ManageOrganizationPageProps extends AppProps {
   actions: AppActions;
@@ -70,6 +70,7 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
         <p className="subtitle">Manage PressPass News Organization</p>
         <h1 className="title is-size-1">{organization.name}</h1>
         <OrganizationForm
+          actions={props.actions}
           organization={organization}
           plans={props.plans}
           subscriptions={props.subscriptions}

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -22,9 +22,6 @@ const OrganizationCard: React.FC<OrganizationCardProps> = (
             <dt>Private?</dt>
             <dd>{organization.private}</dd>
 
-            <dt>Plan:</dt>
-            <dd>{organization.plan}</dd>
-
             <dt>Max users:</dt>
             <dd>{organization.max_users}</dd>
 

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -8,6 +8,7 @@ import { Redirect } from 'react-router';
 interface OrganizationCreatePageProps {
   actions: AppActions;
   plans?: any;
+  subscriptions?: any;
 }
 
 export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
@@ -50,6 +51,7 @@ export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
         <OrganizationForm
           organization={organization}
           plans={props.plans}
+          subscriptions={props.subscriptions}
           onSubmit={handleSubmit}
           errors={errors}
         />

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -49,6 +49,7 @@ export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
       <section className="organization-page">
         <h1 className="title is-size-1">New Organization</h1>
         <OrganizationForm
+          actions={props.actions}
           organization={organization}
           plans={props.plans}
           subscriptions={props.subscriptions}

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { AppActions } from '../store';
+import { Organization } from '../store/organizations/types';
+import { createOrganization } from '../store/organizations/api';
+import OrganizationForm from './OrganizationForm';
+import { Redirect } from 'react-router';
+
+interface OrganizationCreatePageProps {
+  actions: AppActions;
+}
+
+export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
+  props: OrganizationCreatePageProps
+) => {
+  let organization: Organization = {
+    name: '',
+    plan: 'free',
+    private: false,
+    individual: false,
+    payment_failed: false,
+    avatar: '',
+    max_users: 0,
+    slug: '',
+    update_on: new Date(),
+    updated_at: new Date(),
+    uuid: ''
+  };
+  // Saved is -1 if the org is not saved, and is the id
+  // of the created org if it has been created.
+  let [saved, setSaved] = useState(-1);
+  let [errors, setErrors] = useState({});
+
+  const handleSubmit = (updatedOrganization: Organization) => {
+    createOrganization(updatedOrganization, props.actions).then(status => {
+      if (status.ok) {
+        setSaved(status.body.uuid);
+      } else {
+        setErrors(status.body);
+      }
+    });
+  };
+
+  if (saved !== -1) {
+    return <Redirect to={`/organizations/${saved}`} />;
+  } else {
+    return (
+      <section className="organization-page">
+        <h1 className="title is-size-1">New Organization</h1>
+        <OrganizationForm
+          organization={organization}
+          onSubmit={handleSubmit}
+          errors={errors}
+        />
+        <br />
+      </section>
+    );
+  }
+};

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { AppActions } from '../store';
 import { Organization } from '../store/organizations/types';
+import { Plan } from '../store/plans/types';
 import { createOrganization } from '../store/organizations/api';
 import OrganizationForm from './OrganizationForm';
 import { Redirect } from 'react-router';
@@ -16,7 +17,6 @@ export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
 ) => {
   let organization: Organization = {
     name: '',
-    plan: 'free',
     private: false,
     individual: false,
     payment_failed: false,

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -7,6 +7,7 @@ import { Redirect } from 'react-router';
 
 interface OrganizationCreatePageProps {
   actions: AppActions;
+  plans?: any;
 }
 
 export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
@@ -48,6 +49,7 @@ export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
         <h1 className="title is-size-1">New Organization</h1>
         <OrganizationForm
           organization={organization}
+          plans={props.plans}
           onSubmit={handleSubmit}
           errors={errors}
         />

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -22,14 +22,12 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let organization = props.organization;
 
   let [name, setName] = useState(organization.name);
-  let [selectedPlan, setSelectedPlan] = useState(organization.plan);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
   let [avatar, setAvatar] = useState<File | undefined>(undefined);
 
   let newOrganization: Organization = {
     ...organization,
     name: name,
-    plan: selectedPlan,
     private: privateOrg,
     avatar: avatar
   };
@@ -78,20 +76,14 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
           This organization's information and membership is not made public
         </label>
       </Field>
-      <Field errors={errors.plan}>
-        <div className={errors.client_type ? 'select is-danger' : 'select'}>
-          <select
-            value={selectedPlan}
-            onChange={event =>
-              setSelectedPlan(event.target.value.toLowerCase())
-            }
-          >
-            {Object.values(props.plans.plans).map((plan: Plan) => (
-              <option key={plan.name} value={plan.name.toLowerCase()}>
-                {plan.name}
-              </option>
-            ))}
-          </select>
+      <Field>
+        <div className="control">
+          {Object.values(props.plans.plans).map((plan: Plan) => (
+            <label className="checkbox" key={plan.name}>
+              <input type="checkbox" value={plan.name.toLowerCase()} />
+              {plan.name}
+            </label>
+          ))}
         </div>
       </Field>
       <br />

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -4,9 +4,12 @@
 import React, { useState, SyntheticEvent } from 'react';
 import { Organization } from '../store/organizations/types';
 import Field from '../common/Field';
+import { Plan, PlanState } from '../store/plans/types';
+import { organizationReducers } from '../store/organizations/reducers';
 
 interface OrganizationFormProps {
   organization: Organization;
+  plans: PlanState;
   onSubmit: (parameter: Organization) => void;
   errors: any;
 }
@@ -17,14 +20,14 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let organization = props.organization;
 
   let [name, setName] = useState(organization.name);
-  let [plan, setPlan] = useState(organization.plan);
+  let [selectedPlan, setSelectedPlan] = useState(organization.plan);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
   let [avatar, setAvatar] = useState<File | undefined>(undefined);
 
   let newOrganization: Organization = {
     ...organization,
     name: name,
-    plan: plan,
+    plan: selectedPlan,
     private: privateOrg,
     avatar: avatar
   };
@@ -72,6 +75,20 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
           />
           This organization's information and membership is not made public
         </label>
+      </Field>
+      <Field errors={errors.plan}>
+        <div className={errors.client_type ? 'select is-danger' : 'select'}>
+          <select
+            value={selectedPlan}
+            onChange={event => setSelectedPlan(event.target.value)}
+          >
+            {Object.values(props.plans.plans).map((plan: Plan) => (
+              <option key={plan.name} value={plan.name}>
+                {plan.name}
+              </option>
+            ))}
+          </select>
+        </div>
       </Field>
       <br />
       <button type="submit" className="button is-link">

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -6,9 +6,52 @@ import { Organization } from '../store/organizations/types';
 import Field from '../common/Field';
 import { Plan, PlanState } from '../store/plans/types';
 import { organizationReducers } from '../store/organizations/reducers';
-import { SubscriptionState } from '../store/subscriptions/types';
+import { Subscription, SubscriptionState } from '../store/subscriptions/types';
+import {
+  createSubscription,
+  deleteSubscription
+} from '../store/subscriptions/api';
+import { AppActions } from '../store';
+
+interface PlansListProps {
+  plans: PlanState;
+}
+
+const PlansList: React.FC<PlansListProps> = (props: PlansListProps) => {
+  return (
+    <div className="content">
+      <h1 className="subtitle">Plans:</h1>
+      <ul>
+        {Object.values(props.plans.plans).map((plan: Plan) => (
+          <li key={plan.id}>{plan.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+interface SubscriptionsListProps {
+  subscriptions: SubscriptionState;
+}
+const SubscriptionsList: React.FC<SubscriptionsListProps> = (
+  props: SubscriptionsListProps
+) => {
+  return (
+    <div className="content">
+      <h1 className="subtitle">Subscriptions:</h1>
+      <ul>
+        {Object.values(props.subscriptions.subscriptions).map(
+          (subscription: Subscription) => (
+            <li key={subscription.id}>{subscription.plan.name}</li>
+          )
+        )}
+      </ul>
+    </div>
+  );
+};
 
 interface OrganizationFormProps {
+  actions: AppActions;
   organization: Organization;
   plans: PlanState;
   subscriptions: SubscriptionState;
@@ -24,6 +67,7 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let [name, setName] = useState(organization.name);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
   let [avatar, setAvatar] = useState<File | undefined>(undefined);
+  let [subbedPlans, setSubbedPlans] = useState();
 
   let newOrganization: Organization = {
     ...organization,
@@ -33,6 +77,52 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   };
 
   let errors = props.errors;
+
+  // build a list of plans noting which are subscribed
+  const subPlans = Object.values(props.plans.plans).map((plan: Plan) => {
+    plan.subscribed = Object.values(props.subscriptions.subscriptions).some(
+      sub => sub.plan.id === plan.id
+    );
+    return plan;
+  });
+  console.log(subPlans);
+  // setSubbedPlans(subPlans);
+
+  const handleSubscription = event => {
+    let planId = parseInt(event.target.value, 10);
+    if (event.target.checked) {
+      createSubscription(planId, props.organization.uuid, props.actions).then(
+        status => {
+          if (status.ok) {
+            console.log('success', status);
+          } else {
+            console.log('error', status);
+          }
+        }
+      );
+    } else {
+      // first, find the subscription ID using the plan ID?
+      console.log(props.subscriptions);
+      let matchingSub = Object.values(props.subscriptions.subscriptions).find(
+        (sub: Subscription) => {
+          return sub.plan.id === planId;
+        }
+      );
+      if (matchingSub) {
+        console.log('found matching subscription: ', matchingSub);
+        deleteSubscription(matchingSub, props.actions).then(status => {
+          if (status.ok) {
+            console.log('success', status);
+          } else {
+            console.log('error', status);
+          }
+        });
+      } else {
+        console.log('No matching subscription found for planID: ', planId);
+      }
+    }
+    console.log(props.subscriptions);
+  };
 
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
@@ -76,16 +166,8 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
           This organization's information and membership is not made public
         </label>
       </Field>
-      <Field>
-        <div className="control">
-          {Object.values(props.plans.plans).map((plan: Plan) => (
-            <label className="checkbox" key={plan.name}>
-              <input type="checkbox" value={plan.name.toLowerCase()} />
-              {plan.name}
-            </label>
-          ))}
-        </div>
-      </Field>
+      <SubscriptionsList subscriptions={props.subscriptions} />
+      <PlansList plans={props.plans} />
       <br />
       <button type="submit" className="button is-link">
         Save

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -7,6 +7,7 @@ import Field from '../common/Field';
 import { Plan, PlanState } from '../store/plans/types';
 import { Subscription, SubscriptionState } from '../store/subscriptions/types';
 import { AppActions } from '../store';
+import PlanCard from '../plans/PlanCard';
 import SubscriptionCard from '../subscriptions/SubscriptionCard';
 
 interface OrganizationFormProps {
@@ -26,6 +27,14 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let [name, setName] = useState(organization.name);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
   let [avatar, setAvatar] = useState<File | undefined>(undefined);
+
+  // build a list of plans noting which are subscribed
+  Object.values(props.plans.plans).map((plan: Plan) => {
+    plan.subscribed = Object.values(props.subscriptions.subscriptions).some(
+      sub => sub.plan.id === plan.id
+    );
+    return plan;
+  });
 
   let newOrganization: Organization = {
     ...organization,
@@ -78,20 +87,41 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
           This organization's information and membership is not made public
         </label>
       </Field>
-      <div className="columns is-multiline">
+      <hr />
+      <div className="container">
         <h1 className="title">Subscriptions</h1>
-        {Object.values(props.subscriptions.subscriptions).map(
-          (subscription: Subscription) => (
-            <div className="column is-4" key={organization.uuid}>
-              <SubscriptionCard
-                actions={props.actions}
-                key={subscription.id}
-                subscription={subscription}
-                organization={organization.uuid}
-              />
-            </div>
-          )
-        )}
+        <div className="columns">
+          {Object.values(props.subscriptions.subscriptions).map(
+            (subscription: Subscription) => (
+              <div className="column is-4" key={subscription.id}>
+                <SubscriptionCard
+                  actions={props.actions}
+                  key={subscription.id}
+                  subscription={subscription}
+                  organization={organization.uuid}
+                />
+              </div>
+            )
+          )}
+        </div>
+      </div>
+      <hr />
+      <div className="container">
+        <h1 className="title">Available Plans</h1>
+        <div className="columns is-multiline">
+          {Object.values(props.plans.plans)
+            .filter(plan => !plan.subscribed)
+            .map((plan: Plan) => (
+              <div className="column is-4" key={plan.id}>
+                <PlanCard
+                  actions={props.actions}
+                  key={plan.id}
+                  plan={plan}
+                  organization={organization.uuid}
+                />
+              </div>
+            ))}
+        </div>
       </div>
       <br />
       <button type="submit" className="button is-link">

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -1,0 +1,89 @@
+// Form separated from page so that it can DRY-ly be used in both
+// the 'create' component and the 'edit' component.
+
+import React, { useState, SyntheticEvent } from 'react';
+import { Organization } from '../store/organizations/types';
+import Field from '../common/Field';
+
+interface OrganizationFormProps {
+  organization: Organization;
+  onSubmit: (parameter: Organization) => void;
+  errors: any;
+}
+
+const OrganizationForm: React.FC<OrganizationFormProps> = (
+  props: OrganizationFormProps
+) => {
+  let organization = props.organization;
+
+  let [name, setName] = useState(organization.name);
+  let [plan, setPlan] = useState(organization.plan);
+  let [privateOrg, setPrivateOrg] = useState(organization.private);
+  // let [avatar, setAvatar] = useState(organization.avatar);
+  // let [avatar, setAvatar] = useState<File | undefined>(undefined);
+
+  let newOrganization: Organization = {
+    ...organization,
+    name: name,
+    plan: plan,
+    private: privateOrg
+  };
+
+  let errors = props.errors;
+
+  const handleSubmit = (event: SyntheticEvent) => {
+    event.preventDefault();
+    console.log(newOrganization);
+    props.onSubmit(newOrganization);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="limited-width">
+      <Field label="Name" errors={errors.name}>
+        <input
+          className={errors.name ? 'input is-danger' : 'input'}
+          type="text"
+          placeholder="Your organization's name..."
+          value={name}
+          onChange={event => setName(event.target.value)}
+        />
+      </Field>
+      <Field
+        label="Plan"
+        errors={errors.plan}
+        help="The current plan this organization is subscribed to"
+      >
+        <div className={errors.plan ? 'select is-danger' : 'select'}>
+          <select value={plan} onChange={event => setPlan(event.target.value)}>
+            <option value="admin">Admin</option>
+            <option value="beta">Beta</option>
+            <option value="free">Free</option>
+            <option value="manual-pay-organization">
+              Manual Pay Organization
+            </option>
+            <option value="organization">Organization</option>
+            <option value="organization-plus">Organization Plus</option>
+            <option value="professional">Professional</option>
+            <option value="proxy">Proxy</option>
+          </select>
+        </div>
+      </Field>
+      <Field errors={errors.private}>
+        <label className={errors.private ? 'checkbox is-danger' : 'checkbox'}>
+          <input
+            type="checkbox"
+            checked={privateOrg}
+            onChange={event => setPrivateOrg(event.target.checked)}
+          />
+          This organization's information and membership is not made public
+        </label>
+      </Field>
+      <br />
+      <button type="submit" className="button is-link">
+        Save
+      </button>
+    </form>
+  );
+};
+
+export default OrganizationForm;

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -5,50 +5,9 @@ import React, { useState, SyntheticEvent } from 'react';
 import { Organization } from '../store/organizations/types';
 import Field from '../common/Field';
 import { Plan, PlanState } from '../store/plans/types';
-import { organizationReducers } from '../store/organizations/reducers';
 import { Subscription, SubscriptionState } from '../store/subscriptions/types';
-import {
-  createSubscription,
-  deleteSubscription
-} from '../store/subscriptions/api';
 import { AppActions } from '../store';
-
-interface PlansListProps {
-  plans: PlanState;
-}
-
-const PlansList: React.FC<PlansListProps> = (props: PlansListProps) => {
-  return (
-    <div className="content">
-      <h1 className="subtitle">Plans:</h1>
-      <ul>
-        {Object.values(props.plans.plans).map((plan: Plan) => (
-          <li key={plan.id}>{plan.name}</li>
-        ))}
-      </ul>
-    </div>
-  );
-};
-
-interface SubscriptionsListProps {
-  subscriptions: SubscriptionState;
-}
-const SubscriptionsList: React.FC<SubscriptionsListProps> = (
-  props: SubscriptionsListProps
-) => {
-  return (
-    <div className="content">
-      <h1 className="subtitle">Subscriptions:</h1>
-      <ul>
-        {Object.values(props.subscriptions.subscriptions).map(
-          (subscription: Subscription) => (
-            <li key={subscription.id}>{subscription.plan.name}</li>
-          )
-        )}
-      </ul>
-    </div>
-  );
-};
+import SubscriptionCard from '../subscriptions/SubscriptionCard';
 
 interface OrganizationFormProps {
   actions: AppActions;
@@ -67,7 +26,6 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let [name, setName] = useState(organization.name);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
   let [avatar, setAvatar] = useState<File | undefined>(undefined);
-  let [subbedPlans, setSubbedPlans] = useState();
 
   let newOrganization: Organization = {
     ...organization,
@@ -77,52 +35,6 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   };
 
   let errors = props.errors;
-
-  // build a list of plans noting which are subscribed
-  const subPlans = Object.values(props.plans.plans).map((plan: Plan) => {
-    plan.subscribed = Object.values(props.subscriptions.subscriptions).some(
-      sub => sub.plan.id === plan.id
-    );
-    return plan;
-  });
-  console.log(subPlans);
-  // setSubbedPlans(subPlans);
-
-  const handleSubscription = event => {
-    let planId = parseInt(event.target.value, 10);
-    if (event.target.checked) {
-      createSubscription(planId, props.organization.uuid, props.actions).then(
-        status => {
-          if (status.ok) {
-            console.log('success', status);
-          } else {
-            console.log('error', status);
-          }
-        }
-      );
-    } else {
-      // first, find the subscription ID using the plan ID?
-      console.log(props.subscriptions);
-      let matchingSub = Object.values(props.subscriptions.subscriptions).find(
-        (sub: Subscription) => {
-          return sub.plan.id === planId;
-        }
-      );
-      if (matchingSub) {
-        console.log('found matching subscription: ', matchingSub);
-        deleteSubscription(matchingSub, props.actions).then(status => {
-          if (status.ok) {
-            console.log('success', status);
-          } else {
-            console.log('error', status);
-          }
-        });
-      } else {
-        console.log('No matching subscription found for planID: ', planId);
-      }
-    }
-    console.log(props.subscriptions);
-  };
 
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
@@ -166,8 +78,21 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
           This organization's information and membership is not made public
         </label>
       </Field>
-      <SubscriptionsList subscriptions={props.subscriptions} />
-      <PlansList plans={props.plans} />
+      <div className="columns is-multiline">
+        <h1 className="title">Subscriptions</h1>
+        {Object.values(props.subscriptions.subscriptions).map(
+          (subscription: Subscription) => (
+            <div className="column is-4" key={organization.uuid}>
+              <SubscriptionCard
+                actions={props.actions}
+                key={subscription.id}
+                subscription={subscription}
+                organization={organization.uuid}
+              />
+            </div>
+          )
+        )}
+      </div>
       <br />
       <button type="submit" className="button is-link">
         Save

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -19,21 +19,20 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
   let [name, setName] = useState(organization.name);
   let [plan, setPlan] = useState(organization.plan);
   let [privateOrg, setPrivateOrg] = useState(organization.private);
-  // let [avatar, setAvatar] = useState(organization.avatar);
-  // let [avatar, setAvatar] = useState<File | undefined>(undefined);
+  let [avatar, setAvatar] = useState<File | undefined>(undefined);
 
   let newOrganization: Organization = {
     ...organization,
     name: name,
     plan: plan,
-    private: privateOrg
+    private: privateOrg,
+    avatar: avatar
   };
 
   let errors = props.errors;
 
   const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
-    console.log(newOrganization);
     props.onSubmit(newOrganization);
   };
 
@@ -49,24 +48,20 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
         />
       </Field>
       <Field
-        label="Plan"
-        errors={errors.plan}
-        help="The current plan this organization is subscribed to"
+        label="Avatar"
+        errors={errors.avatar}
+        help="If you do not upload a file, the current photo will be kept."
       >
-        <div className={errors.plan ? 'select is-danger' : 'select'}>
-          <select value={plan} onChange={event => setPlan(event.target.value)}>
-            <option value="admin">Admin</option>
-            <option value="beta">Beta</option>
-            <option value="free">Free</option>
-            <option value="manual-pay-organization">
-              Manual Pay Organization
-            </option>
-            <option value="organization">Organization</option>
-            <option value="organization-plus">Organization Plus</option>
-            <option value="professional">Professional</option>
-            <option value="proxy">Proxy</option>
-          </select>
-        </div>
+        <input
+          className={errors.avatar ? 'input is-danger' : 'input'}
+          type="file"
+          placeholder="Your organization's logo..."
+          onChange={event =>
+            setAvatar(
+              event.target.files === null ? undefined : event.target.files[0]
+            )
+          }
+        />
       </Field>
       <Field errors={errors.private}>
         <label className={errors.private ? 'checkbox is-danger' : 'checkbox'}>

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -80,10 +80,12 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
         <div className={errors.client_type ? 'select is-danger' : 'select'}>
           <select
             value={selectedPlan}
-            onChange={event => setSelectedPlan(event.target.value)}
+            onChange={event =>
+              setSelectedPlan(event.target.value.toLowerCase())
+            }
           >
             {Object.values(props.plans.plans).map((plan: Plan) => (
-              <option key={plan.name} value={plan.name}>
+              <option key={plan.name} value={plan.name.toLowerCase()}>
                 {plan.name}
               </option>
             ))}

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -6,10 +6,12 @@ import { Organization } from '../store/organizations/types';
 import Field from '../common/Field';
 import { Plan, PlanState } from '../store/plans/types';
 import { organizationReducers } from '../store/organizations/reducers';
+import { SubscriptionState } from '../store/subscriptions/types';
 
 interface OrganizationFormProps {
   organization: Organization;
   plans: PlanState;
+  subscriptions: SubscriptionState;
   onSubmit: (parameter: Organization) => void;
   errors: any;
 }

--- a/src/organization/OrganizationPage.tsx
+++ b/src/organization/OrganizationPage.tsx
@@ -1,13 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { AppActions } from '../store';
+import { OrganizationState, Organization } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
 import { AppProps } from '../store';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { Link } from 'react-router-dom';
 
 interface OrganizationPageProps extends AppProps {
-  id: string;
+  organization: string;
+  organizations: OrganizationState;
+  actions: AppActions;
 }
 
 export const OrganizationPage = (props: OrganizationPageProps) => {
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  let organization = props.organizations.organizations[props.organization];
   return (
-    <p>Organization page (id {props.id}) (<Link to={`./${props.id}/manage`}>manage</Link>)</p>
-  )
-}
+    <section className="organization-page">
+      <p className="subtitle">PressPass News Organization</p>
+      <h1 className="title is-size-1">{organization.name}</h1>
+      <table className="table">
+        <tbody>
+          <tr>
+            <td className="has-text-weight-bold">Name</td>
+            <td>{organization.name}</td>
+          </tr>
+          <tr>
+            <td className="has-text-weight-bold">Avatar</td>
+            <td>{organization.avatar}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Organization page (id {organization.uuid}) (
+        <Link to={`./${organization.id}/manage`}>manage</Link>)
+      </p>
+    </section>
+  );
+};

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -6,6 +6,7 @@ import { OrganizationPage } from './OrganizationPage';
 import { ManageOrganizationPage } from './ManageOrganizationPage';
 import { OrganizationsList } from './OrganizationsList';
 import { InvitationPage } from '../invitation/InvitationPage';
+import { InvitePage } from '../invitation/InvitePage';
 
 export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
@@ -37,6 +38,14 @@ export const getRoutes = (props: AppProps) => {
       path="/organizations/:id/invitation"
       render={routeProps => (
         <InvitationPage {...props} id={routeProps.match.params.id} />
+      )}
+      {...authProps}
+    />,
+    <ProtectedRoute
+      exact
+      path="/organizations/:id/invite"
+      render={routeProps => (
+        <InvitePage {...props} organization={routeProps.match.params.id} />
       )}
       {...authProps}
     />

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -28,7 +28,10 @@ export const getRoutes = (props: AppProps) => {
       exact
       path="/organizations/:id"
       render={routeProps => (
-        <OrganizationPage {...props} id={routeProps.match.params.id} />
+        <OrganizationPage
+          {...props}
+          organization={routeProps.match.params.id}
+        />
       )}
       {...authProps}
     />,
@@ -36,7 +39,10 @@ export const getRoutes = (props: AppProps) => {
       exact
       path="/organizations/:id/manage"
       render={routeProps => (
-        <ManageOrganizationPage {...props} id={routeProps.match.params.id} />
+        <ManageOrganizationPage
+          {...props}
+          organization={routeProps.match.params.id}
+        />
       )}
       {...authProps}
     />,

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -41,6 +41,7 @@ export const getRoutes = (props: AppProps) => {
       render={routeProps => (
         <ManageOrganizationPage
           {...props}
+          plans={props.plans}
           organization={routeProps.match.params.id}
         />
       )}

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -5,6 +5,7 @@ import { ProtectedRoute } from '../common/routing';
 import { OrganizationPage } from './OrganizationPage';
 import { ManageOrganizationPage } from './ManageOrganizationPage';
 import { OrganizationsList } from './OrganizationsList';
+import { OrganizationCreatePage } from './OrganizationCreatePage';
 import { InvitationPage } from '../invitation/InvitationPage';
 import { InvitePage } from '../invitation/InvitePage';
 
@@ -17,6 +18,12 @@ export const getRoutes = (props: AppProps) => {
         organizations={props.organizations}
       />
     </ProtectedRoute>,
+    <ProtectedRoute
+      exact
+      path="/organizations/create"
+      render={routeProps => <OrganizationCreatePage {...props} />}
+      {...authProps}
+    />,
     <ProtectedRoute
       exact
       path="/organizations/:id"

--- a/src/plans/PlanCard.tsx
+++ b/src/plans/PlanCard.tsx
@@ -9,19 +9,33 @@ interface PlanCardProps {
   actions: AppActions;
 }
 
+const SubscribeFooter: React.FC<PlanCardProps> = (props: PlanCardProps) => {
+  const subscribeToPlan = () => {
+    createSubscription(props.plan.id, props.organization, props.actions).then(
+      status => {
+        if (status.ok) {
+          console.log('success', status);
+        } else {
+          console.log('error', status);
+        }
+      }
+    );
+  };
+
+  if (props.plan.base_price > 0) {
+    return <footer className="card-footer">Paid subs TK</footer>;
+  }
+  return (
+    <footer className="card-footer">
+      <a onClick={subscribeToPlan} className="card-footer-item">
+        Subscribe
+      </a>
+    </footer>
+  );
+};
 const PlanCard: React.FC<PlanCardProps> = (props: PlanCardProps) => {
   let plan = props.plan;
   let organization = props.organization;
-
-  const subscribeToPlan = () => {
-    createSubscription(plan.id, organization, props.actions).then(status => {
-      if (status.ok) {
-        console.log('success', status);
-      } else {
-        console.log('error', status);
-      }
-    });
-  };
 
   return (
     <div className="card">
@@ -39,11 +53,11 @@ const PlanCard: React.FC<PlanCardProps> = (props: PlanCardProps) => {
           </div>
         </div>
       </div>
-      <footer className="card-footer">
-        <a onClick={subscribeToPlan} className="card-footer-item">
-          Subscribe
-        </a>
-      </footer>
+      <SubscribeFooter
+        plan={plan}
+        organization={organization}
+        actions={props.actions}
+      />
     </div>
   );
 };

--- a/src/plans/PlanCard.tsx
+++ b/src/plans/PlanCard.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { AppActions } from '../store';
+import { Plan } from '../store/plans/types';
+import { createSubscription } from '../store/subscriptions/api';
+
+interface PlanCardProps {
+  plan: Plan;
+  organization: string;
+  actions: AppActions;
+}
+
+const PlanCard: React.FC<PlanCardProps> = (props: PlanCardProps) => {
+  let plan = props.plan;
+  let organization = props.organization;
+
+  const subscribeToPlan = () => {
+    createSubscription(plan.id, organization, props.actions).then(status => {
+      if (status.ok) {
+        console.log('success', status);
+      } else {
+        console.log('error', status);
+      }
+    });
+  };
+
+  return (
+    <div className="card">
+      <header className="card-header">
+        <p className="card-header-title">{plan.name}</p>
+      </header>
+
+      <div className="card-content">
+        <div className="content">
+          <div className="media-content">
+            <div className="content">
+              Lorem ipsum about the plan, maybe a link, not sure what might go
+              here.
+            </div>
+          </div>
+        </div>
+      </div>
+      <footer className="card-footer">
+        <a onClick={subscribeToPlan} className="card-footer-item">
+          Subscribe
+        </a>
+      </footer>
+    </div>
+  );
+};
+
+export default PlanCard;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -57,7 +57,8 @@ import { PlanState } from './plans/types';
 // Subscriptions
 import {
   upsertSubscription,
-  upsertSubscriptions
+  upsertSubscriptions,
+  deleteSubscription
 } from './subscriptions/actions';
 import { subscriptionReducers } from './subscriptions/reducers';
 import { SubscriptionState } from './subscriptions/types';
@@ -104,6 +105,7 @@ export interface AppActions {
   upsertPlans: typeof upsertPlans;
   upsertSubscription: typeof upsertSubscription;
   upsertSubscriptions: typeof upsertSubscriptions;
+  deleteSubscription: typeof deleteSubscription;
   upsertInvitation: typeof upsertInvitation;
   upsertInvitations: typeof upsertInvitations;
   deleteInvitation: typeof deleteInvitation;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,21 +22,7 @@ import {
 import { entitlementReducers } from './entitlements/reducers';
 import { EntitlementState } from './entitlements/types';
 
-// Users
-import { upsertSelfUser } from './users/actions';
-import { usersReducers } from './users/reducers';
-import { UsersState } from './users/types';
-
-// Organizations
-import {
-  upsertOrganization,
-  upsertOrganizations,
-  deleteOrganization
-} from './organizations/actions';
-import { organizationReducers } from './organizations/reducers';
-import { OrganizationState } from './organizations/types';
-
-//`Memberships
+//Invitations
 import {
   upsertInvitation,
   upsertInvitations,
@@ -54,6 +40,25 @@ import {
 import { membershipReducers } from './memberships/reducers';
 import { MembershipState } from './memberships/types';
 
+// Organizations
+import {
+  upsertOrganization,
+  upsertOrganizations,
+  deleteOrganization
+} from './organizations/actions';
+import { organizationReducers } from './organizations/reducers';
+import { OrganizationState } from './organizations/types';
+
+// Plans
+import { upsertPlan, upsertPlans } from './plans/actions';
+import { planReducers } from './plans/reducers';
+import { PlanState } from './plans/types';
+
+// Users
+import { upsertSelfUser } from './users/actions';
+import { usersReducers } from './users/reducers';
+import { UsersState } from './users/types';
+
 const reducers = combineReducers({
   auth: authReducers,
   clients: clientReducers,
@@ -61,6 +66,7 @@ const reducers = combineReducers({
   organizations: organizationReducers,
   invitations: invitationReducers,
   memberships: membershipReducers,
+  plans: planReducers,
   users: usersReducers
 });
 
@@ -85,6 +91,8 @@ export interface AppActions {
   upsertMembership: typeof upsertMembership;
   upsertMemberships: typeof upsertMemberships;
   deleteMembership: typeof deleteMembership;
+  upsertPlan: typeof upsertPlan;
+  upsertPlans: typeof upsertPlans;
   upsertInvitation: typeof upsertInvitation;
   upsertInvitations: typeof upsertInvitations;
   deleteInvitation: typeof deleteInvitation;
@@ -102,6 +110,7 @@ export interface AppProps {
   organizations: OrganizationState;
   invitations: InvitationState;
   memberships: MembershipState;
+  plans: PlanState;
   users: UsersState;
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,6 +54,14 @@ import { upsertPlan, upsertPlans } from './plans/actions';
 import { planReducers } from './plans/reducers';
 import { PlanState } from './plans/types';
 
+// Subscriptions
+import {
+  upsertSubscription,
+  upsertSubscriptions
+} from './subscriptions/actions';
+import { subscriptionReducers } from './subscriptions/reducers';
+import { SubscriptionState } from './subscriptions/types';
+
 // Users
 import { upsertSelfUser } from './users/actions';
 import { usersReducers } from './users/reducers';
@@ -67,6 +75,7 @@ const reducers = combineReducers({
   invitations: invitationReducers,
   memberships: membershipReducers,
   plans: planReducers,
+  subscriptions: subscriptionReducers,
   users: usersReducers
 });
 
@@ -93,6 +102,8 @@ export interface AppActions {
   deleteMembership: typeof deleteMembership;
   upsertPlan: typeof upsertPlan;
   upsertPlans: typeof upsertPlans;
+  upsertSubscription: typeof upsertSubscription;
+  upsertSubscriptions: typeof upsertSubscriptions;
   upsertInvitation: typeof upsertInvitation;
   upsertInvitations: typeof upsertInvitations;
   deleteInvitation: typeof deleteInvitation;
@@ -111,6 +122,7 @@ export interface AppProps {
   invitations: InvitationState;
   memberships: MembershipState;
   plans: PlanState;
+  subscriptions: SubscriptionState;
   users: UsersState;
 }
 

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -204,9 +204,13 @@ export const createInvitation = (
   )
     .then(checkAuth(actions)) // Necessary
     .then(response =>
-      validate(response, () =>
-        notify('Successfully sent the invitation.', 'success')
-      )
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertInvitation(status.body as Invitation);
+        notify(
+          '[TODO remove this?] Successfully sent the invitation.',
+          'success'
+        );
+      })
     );
 
 export const deleteInvitation = (invitation: Invitation, actions: AppActions) =>

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -7,7 +7,7 @@ import {
   notify,
   GET,
   PATCH,
-  PUT,
+  JSON_POST,
   DELETE
 } from '../../utils';
 import { Invitation, InvitationState } from './types';
@@ -192,32 +192,22 @@ export const rejectInvitation = (
 };
 
 export const createInvitation = (
-  invitation: Invitation,
+  organization_id: string,
+  email: string,
   actions: AppActions
-) => {
-  let formData = new FormData();
-  let packagedInvitation: any = serializeInvitation(invitation);
-  for (let key of Object.keys(packagedInvitation)) {
-    formData.append(key, packagedInvitation[key]);
-  }
-  return (
-    cfetch(
-      `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${invitation.organization}/invitations/${invitation.user}`,
-      PUT(formData)
-    )
-      .then(checkAuth(actions))
-      // Cannot call upsert invitation here, because IDs are assigned on the server side
-      .then(response =>
-        validate(response, (status: ItemizedResponse) => {
-          actions.upsertInvitation(status.body as Invitation);
-          notify(
-            `Successfully created invitation for user ${invitation.user} in organization ${invitation.organization}.`,
-            'success'
-          );
-        })
+) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization_id}/invitations/`,
+    JSON_POST({
+      email: email
+    })
+  )
+    .then(checkAuth(actions)) // Necessary
+    .then(response =>
+      validate(response, () =>
+        notify('Successfully sent the invitation.', 'success')
       )
-  );
-};
+    );
 
 export const deleteInvitation = (invitation: Invitation, actions: AppActions) =>
   cfetch(

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -8,6 +8,7 @@ export interface Invitation {
   uuid: number;
   organization: Organization;
   user: number;
+  email: string;
   request: boolean;
   created_at: Date;
   accepted_at: Date;

--- a/src/store/organizations/api.ts
+++ b/src/store/organizations/api.ts
@@ -17,7 +17,6 @@ const serializeOrganization = (organization: Organization) => ({
   name: organization.name || '',
   avatar: organization.avatar || '',
   slug: organization.slug,
-  plan: organization.plan,
   max_users: organization.max_users,
   individual: organization.individual,
   private: organization.private

--- a/src/store/organizations/types.ts
+++ b/src/store/organizations/types.ts
@@ -13,7 +13,7 @@ export interface Organization {
   update_on: Date;
   updated_at: Date;
   payment_failed: boolean;
-  avatar: string;
+  avatar?: string | File;
 }
 
 export interface OrganizationState {

--- a/src/store/organizations/types.ts
+++ b/src/store/organizations/types.ts
@@ -6,7 +6,6 @@ export interface Organization {
   uuid: string;
   name: string;
   slug: string;
-  plan: string;
   max_users: number;
   individual: boolean;
   private: boolean;

--- a/src/store/plans/actions.ts
+++ b/src/store/plans/actions.ts
@@ -1,0 +1,31 @@
+import {
+  UPSERT_PLAN,
+  Plan,
+  UPSERT_PLANS,
+  UpsertPlanAction,
+  UpsertPlansAction
+} from './types';
+
+export function upsertPlan(plan: Plan): UpsertPlanAction {
+  return {
+    type: UPSERT_PLAN,
+    plan: plan
+  };
+}
+
+// This action is necessary because if one wants to
+// upsert multiple plans into the store at load time,
+// calling each `upsertPlan` individually would cause
+// the 'hydrated' field to be set to `true` after the first
+// upsert (but before all the data has been loaded). This
+// can cause issues when there are multiple plans,
+// as a view might be waiting for `hydrated` to be `true`
+// before displaying data from a particular plan. If
+// `hydrated` is set to `true` too early, this can cause
+// these views to fail.
+export function upsertPlans(plans: Plan[]): UpsertPlansAction {
+  return {
+    type: UPSERT_PLANS,
+    plans: plans
+  };
+}

--- a/src/store/plans/api.ts
+++ b/src/store/plans/api.ts
@@ -1,0 +1,32 @@
+import { AppActions } from '..';
+import { checkAuth, cfetch, GET } from '../../utils';
+import { Plan, PlanState } from './types';
+
+const serializePlan = (plan: Plan) => ({
+  name: plan.name || '',
+  slug: plan.slug,
+  minimum_users: plan.minimum_users,
+  for_individuals: plan.for_individuals,
+  for_groups: plan.for_groups,
+  base_price: plan.base_price,
+  price_per_user: plan.price_per_user
+  // Explicitly setting each field is necessary here, because
+  // not all of the fields in plan are write-available, and
+  // including them in the request would result in a 400 response.
+});
+
+export const fetchPlans = (actions: AppActions) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/plans/`, GET)
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertPlans(data.results)]))
+    .catch(error => {
+      console.log(actions);
+      console.error('API Error fetchPlans', error, error.code);
+    });
+
+export const ensurePlans = (actions: AppActions, plans: PlanState) => {
+  if (!plans.hydrated) {
+    return fetchPlans(actions);
+  }
+};

--- a/src/store/plans/reducers.ts
+++ b/src/store/plans/reducers.ts
@@ -16,7 +16,7 @@ export function planReducers(
         hydrated: true
       };
       for (let plan of action.plans) {
-        incomingObject.plans[plan.name] = plan;
+        incomingObject.plans[plan.id] = plan;
       }
       return Object.assign({}, state, incomingObject);
     }
@@ -25,7 +25,7 @@ export function planReducers(
         plans: Object.assign({}, state.plans),
         hydrated: true
       };
-      incomingObject.plans[action.plan.name] = action.plan;
+      incomingObject.plans[action.plan.id] = action.plan;
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/plans/reducers.ts
+++ b/src/store/plans/reducers.ts
@@ -1,0 +1,34 @@
+import { PlanAction, UPSERT_PLAN, PlanState, UPSERT_PLANS } from './types';
+
+const initialState: PlanState = {
+  plans: {},
+  hydrated: false
+};
+
+export function planReducers(
+  state = initialState,
+  action: PlanAction
+): PlanState {
+  switch (action.type) {
+    case UPSERT_PLANS: {
+      let incomingObject: PlanState = {
+        plans: Object.assign({}, state.plans),
+        hydrated: true
+      };
+      for (let plan of action.plans) {
+        incomingObject.plans[plan.name] = plan;
+      }
+      return Object.assign({}, state, incomingObject);
+    }
+    case UPSERT_PLAN: {
+      let incomingObject: PlanState = {
+        plans: Object.assign({}, state.plans),
+        hydrated: true
+      };
+      incomingObject.plans[action.plan.name] = action.plan;
+      return Object.assign({}, state, incomingObject);
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/plans/types.ts
+++ b/src/store/plans/types.ts
@@ -1,0 +1,29 @@
+export const UPSERT_PLAN = 'UPSERT_PLAN';
+export const UPSERT_PLANS = 'UPSERT_PLANS';
+
+export interface Plan {
+  name: string;
+  slug: string;
+  minimum_users: number;
+  base_price: number;
+  price_per_user: number;
+  for_individuals: boolean;
+  for_groups: boolean;
+}
+
+export interface PlanState {
+  plans: { [name: string]: Plan };
+  hydrated: boolean;
+}
+
+export interface UpsertPlanAction {
+  type: typeof UPSERT_PLAN;
+  plan: Plan;
+}
+
+export interface UpsertPlansAction {
+  type: typeof UPSERT_PLANS;
+  plans: Plan[];
+}
+
+export type PlanAction = UpsertPlanAction | UpsertPlansAction;

--- a/src/store/plans/types.ts
+++ b/src/store/plans/types.ts
@@ -2,6 +2,7 @@ export const UPSERT_PLAN = 'UPSERT_PLAN';
 export const UPSERT_PLANS = 'UPSERT_PLANS';
 
 export interface Plan {
+  id: number;
   name: string;
   slug: string;
   minimum_users: number;
@@ -9,10 +10,11 @@ export interface Plan {
   price_per_user: number;
   for_individuals: boolean;
   for_groups: boolean;
+  subscribed: boolean;
 }
 
 export interface PlanState {
-  plans: { [name: string]: Plan };
+  plans: { [id: number]: Plan };
   hydrated: boolean;
 }
 

--- a/src/store/subscriptions/actions.ts
+++ b/src/store/subscriptions/actions.ts
@@ -1,9 +1,11 @@
 import {
   UPSERT_SUBSCRIPTION,
   UPSERT_SUBSCRIPTIONS,
+  DELETE_SUBSCRIPTION,
   Subscription,
   UpsertSubscriptionAction,
-  UpsertSubscriptionsAction
+  UpsertSubscriptionsAction,
+  DeleteSubscriptionAction
 } from './types';
 
 export function upsertSubscription(
@@ -21,5 +23,14 @@ export function upsertSubscriptions(
   return {
     type: UPSERT_SUBSCRIPTIONS,
     subscriptions: subscriptions
+  };
+}
+
+export function deleteSubscription(
+  subscription: Subscription
+): DeleteSubscriptionAction {
+  return {
+    type: DELETE_SUBSCRIPTION,
+    subscription: subscription
   };
 }

--- a/src/store/subscriptions/actions.ts
+++ b/src/store/subscriptions/actions.ts
@@ -15,24 +15,9 @@ export function upsertSubscription(
   };
 }
 
-// This action is necessary because if one wants to
-// upsert multiple subscriptions into the store at load time,
-// calling each `upsertSubscription` individually would cause
-// the 'hydrated' field to be set to `true` after the first
-// upsert (but before all the data has been loaded). This
-// can cause issues when there are multiple subscriptions,
-// as a view might be waiting for `hydrated` to be `true`
-// before displaying data from a particular subscription. If
-// `hydrated` is set to `true` too early, this can cause
-// these views to fail.
 export function upsertSubscriptions(
-  uuid: string,
   subscriptions: Subscription[]
 ): UpsertSubscriptionsAction {
-  //ensure each subscription has a user id
-  Object.values(subscriptions).map((subscription: Subscription) => {
-    subscription.user = uuid;
-  });
   return {
     type: UPSERT_SUBSCRIPTIONS,
     subscriptions: subscriptions

--- a/src/store/subscriptions/actions.ts
+++ b/src/store/subscriptions/actions.ts
@@ -1,0 +1,40 @@
+import {
+  UPSERT_SUBSCRIPTION,
+  UPSERT_SUBSCRIPTIONS,
+  Subscription,
+  UpsertSubscriptionAction,
+  UpsertSubscriptionsAction
+} from './types';
+
+export function upsertSubscription(
+  subscription: Subscription
+): UpsertSubscriptionAction {
+  return {
+    type: UPSERT_SUBSCRIPTION,
+    subscription: subscription
+  };
+}
+
+// This action is necessary because if one wants to
+// upsert multiple subscriptions into the store at load time,
+// calling each `upsertSubscription` individually would cause
+// the 'hydrated' field to be set to `true` after the first
+// upsert (but before all the data has been loaded). This
+// can cause issues when there are multiple subscriptions,
+// as a view might be waiting for `hydrated` to be `true`
+// before displaying data from a particular subscription. If
+// `hydrated` is set to `true` too early, this can cause
+// these views to fail.
+export function upsertSubscriptions(
+  uuid: string,
+  subscriptions: Subscription[]
+): UpsertSubscriptionsAction {
+  //ensure each subscription has a user id
+  Object.values(subscriptions).map((subscription: Subscription) => {
+    subscription.user = uuid;
+  });
+  return {
+    type: UPSERT_SUBSCRIPTIONS,
+    subscriptions: subscriptions
+  };
+}

--- a/src/store/subscriptions/api.ts
+++ b/src/store/subscriptions/api.ts
@@ -74,10 +74,11 @@ export const createSubscription = (
 
 export const deleteSubscription = (
   subscription: Subscription,
+  organization: string,
   actions: AppActions
 ) =>
   cfetch(
-    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${subscription.organization.uuid}/subscriptions/${subscription.id}`,
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization}/subscriptions/${subscription.id}`,
     DELETE
   )
     .then(checkAuth(actions))
@@ -85,7 +86,7 @@ export const deleteSubscription = (
       validate(response, () => {
         actions.deleteSubscription(subscription);
         notify(
-          `Successfully deleted ${subscription.id} from organization ${subscription.organization.name}.`,
+          `Successfully deleted subscription ID#${subscription.id} from organization ${organization}.`,
           'success'
         );
       })

--- a/src/store/subscriptions/api.ts
+++ b/src/store/subscriptions/api.ts
@@ -24,7 +24,7 @@ export const fetchSubscriptionsForOrganization = (
   uuid: string
 ) =>
   cfetch(
-    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/subscriptions/`,
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/subscriptions/?expand=plan`,
     GET
   )
     .then(checkAuth(actions))

--- a/src/store/subscriptions/api.ts
+++ b/src/store/subscriptions/api.ts
@@ -1,0 +1,78 @@
+import { AppActions } from '..';
+import {
+  checkAuth,
+  cfetch,
+  validate,
+  ItemizedResponse,
+  notify,
+  GET,
+  JSON_POST
+} from '../../utils';
+import { Subscription, SubscriptionState } from './types';
+
+const serializeSubscription = (subscription: Subscription) => ({
+  plan: subscription.plan,
+  organization: subscription.organization
+  // Explicitly setting each field is necessary here, because
+  // not all of the fields in subscription are write-available, and
+  // including them in the request would result in a 400 response.
+});
+
+export const fetchSubscriptionsForOrganization = (
+  actions: AppActions,
+  uuid: string
+) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/subscriptions/`,
+    GET
+  )
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data =>
+      Promise.all([actions.upsertSubscriptions(uuid, data.results)])
+    )
+    .catch(error => {
+      console.error(
+        'API Error fetchSubscriptionsForOrganization',
+        error,
+        error.code
+      );
+    });
+
+export const ensureSubscriptionsForOrganization = (
+  actions: AppActions,
+  uuid: string,
+  subscriptions: SubscriptionState
+) => {
+  if (!subscriptions.hydrated) {
+    return fetchSubscriptionsForOrganization(actions, uuid);
+  }
+};
+
+export const createSubscription = (
+  subscription: Subscription,
+  actions: AppActions
+) => {
+  let formData = new FormData();
+  let packagedSubscription: any = serializeSubscription(subscription);
+  for (let key of Object.keys(packagedSubscription)) {
+    formData.append(key, packagedSubscription[key]);
+  }
+  return (
+    cfetch(
+      `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${subscription.organization}/subscriptions/`,
+      JSON_POST(formData)
+    )
+      .then(checkAuth(actions))
+      // Cannot call upsert subscription here, because IDs are assigned on the server side
+      .then(response =>
+        validate(response, (status: ItemizedResponse) => {
+          actions.upsertSubscription(status.body as Subscription);
+          notify(
+            `Successfully created subscription for organization ${subscription.organization} to plan ${subscription.plan}.`,
+            'success'
+          );
+        })
+      )
+  );
+};

--- a/src/store/subscriptions/api.ts
+++ b/src/store/subscriptions/api.ts
@@ -28,9 +28,7 @@ export const fetchSubscriptionsForOrganization = (
   )
     .then(checkAuth(actions))
     .then(response => response.json())
-    .then(data =>
-      Promise.all([actions.upsertSubscriptions(uuid, data.results)])
-    )
+    .then(data => Promise.all([actions.upsertSubscriptions(data.results)]))
     .catch(error => {
       console.error(
         'API Error fetchSubscriptionsForOrganization',

--- a/src/store/subscriptions/reducers.ts
+++ b/src/store/subscriptions/reducers.ts
@@ -32,7 +32,7 @@ export function subscriptionReducers(
         subscriptions: Object.assign({}, state.subscriptions),
         hydrated: true
       };
-      incomingObject.subscriptions[action.subscription.user] =
+      incomingObject.subscriptions[action.subscription.organization.uuid] =
         action.subscription;
       return Object.assign({}, state, incomingObject);
     }

--- a/src/store/subscriptions/reducers.ts
+++ b/src/store/subscriptions/reducers.ts
@@ -1,0 +1,42 @@
+import {
+  SubscriptionAction,
+  UPSERT_SUBSCRIPTION,
+  SubscriptionState,
+  UPSERT_SUBSCRIPTIONS
+} from './types';
+
+const initialState: SubscriptionState = {
+  subscriptions: {},
+  hydrated: false
+};
+
+export function subscriptionReducers(
+  state = initialState,
+  action: SubscriptionAction
+): SubscriptionState {
+  switch (action.type) {
+    case UPSERT_SUBSCRIPTIONS: {
+      let incomingObject: SubscriptionState = {
+        subscriptions: Object.assign({}, state.subscriptions),
+        hydrated: true
+      };
+      for (let subscription of action.subscriptions) {
+        incomingObject.subscriptions[
+          subscription.organization.uuid
+        ] = subscription;
+      }
+      return Object.assign({}, state, incomingObject);
+    }
+    case UPSERT_SUBSCRIPTION: {
+      let incomingObject: SubscriptionState = {
+        subscriptions: Object.assign({}, state.subscriptions),
+        hydrated: true
+      };
+      incomingObject.subscriptions[action.subscription.user] =
+        action.subscription;
+      return Object.assign({}, state, incomingObject);
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/subscriptions/reducers.ts
+++ b/src/store/subscriptions/reducers.ts
@@ -2,7 +2,8 @@ import {
   SubscriptionAction,
   UPSERT_SUBSCRIPTION,
   SubscriptionState,
-  UPSERT_SUBSCRIPTIONS
+  UPSERT_SUBSCRIPTIONS,
+  DELETE_SUBSCRIPTION
 } from './types';
 
 const initialState: SubscriptionState = {
@@ -21,9 +22,7 @@ export function subscriptionReducers(
         hydrated: true
       };
       for (let subscription of action.subscriptions) {
-        incomingObject.subscriptions[
-          subscription.organization.uuid
-        ] = subscription;
+        incomingObject.subscriptions[subscription.id] = subscription;
       }
       return Object.assign({}, state, incomingObject);
     }
@@ -32,8 +31,16 @@ export function subscriptionReducers(
         subscriptions: Object.assign({}, state.subscriptions),
         hydrated: true
       };
-      incomingObject.subscriptions[action.subscription.organization.uuid] =
+      incomingObject.subscriptions[action.subscription.id] =
         action.subscription;
+      return Object.assign({}, state, incomingObject);
+    }
+    case DELETE_SUBSCRIPTION: {
+      let incomingObject: SubscriptionState = {
+        subscriptions: Object.assign({}, state.subscriptions),
+        hydrated: true
+      };
+      delete incomingObject.subscriptions[action.subscription.id];
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/subscriptions/types.ts
+++ b/src/store/subscriptions/types.ts
@@ -5,9 +5,8 @@ export const UPSERT_SUBSCRIPTION = 'UPSERT_SUBSCRIPTION';
 export const UPSERT_SUBSCRIPTIONS = 'UPSERT_SUBSCRIPTIONS';
 
 export interface Subscription {
-  user: string;
   organization: Organization;
-  plan: Plan;
+  plan: string;
 }
 
 export interface SubscriptionState {

--- a/src/store/subscriptions/types.ts
+++ b/src/store/subscriptions/types.ts
@@ -1,0 +1,30 @@
+import { Organization } from '../organizations/types';
+import { Plan } from '../plans/types';
+
+export const UPSERT_SUBSCRIPTION = 'UPSERT_SUBSCRIPTION';
+export const UPSERT_SUBSCRIPTIONS = 'UPSERT_SUBSCRIPTIONS';
+
+export interface Subscription {
+  user: string;
+  organization: Organization;
+  plan: Plan;
+}
+
+export interface SubscriptionState {
+  subscriptions: { [id: number]: Subscription };
+  hydrated: boolean;
+}
+
+export interface UpsertSubscriptionAction {
+  type: typeof UPSERT_SUBSCRIPTION;
+  subscription: Subscription;
+}
+
+export interface UpsertSubscriptionsAction {
+  type: typeof UPSERT_SUBSCRIPTIONS;
+  subscriptions: Subscription[];
+}
+
+export type SubscriptionAction =
+  | UpsertSubscriptionAction
+  | UpsertSubscriptionsAction;

--- a/src/store/subscriptions/types.ts
+++ b/src/store/subscriptions/types.ts
@@ -3,10 +3,12 @@ import { Plan } from '../plans/types';
 
 export const UPSERT_SUBSCRIPTION = 'UPSERT_SUBSCRIPTION';
 export const UPSERT_SUBSCRIPTIONS = 'UPSERT_SUBSCRIPTIONS';
+export const DELETE_SUBSCRIPTION = 'DELETE_SUBSCRIPTION';
 
 export interface Subscription {
+  id: number;
   organization: Organization;
-  plan: string;
+  plan: Plan;
 }
 
 export interface SubscriptionState {
@@ -24,6 +26,12 @@ export interface UpsertSubscriptionsAction {
   subscriptions: Subscription[];
 }
 
+export interface DeleteSubscriptionAction {
+  type: typeof DELETE_SUBSCRIPTION;
+  subscription: Subscription;
+}
+
 export type SubscriptionAction =
   | UpsertSubscriptionAction
-  | UpsertSubscriptionsAction;
+  | UpsertSubscriptionsAction
+  | DeleteSubscriptionAction;

--- a/src/subscriptions/SubscriptionCard.tsx
+++ b/src/subscriptions/SubscriptionCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { AppActions } from '../store';
+import { Subscription } from '../store/subscriptions/types';
+import { deleteSubscription } from '../store/subscriptions/api';
+
+interface SubscriptionCardProps {
+  subscription: Subscription;
+  organization: string;
+  actions: AppActions;
+}
+
+const SubscriptionCard: React.FC<SubscriptionCardProps> = (
+  props: SubscriptionCardProps
+) => {
+  let subscription = props.subscription;
+  let organization = props.organization;
+
+  const removeSubscription = () => {
+    deleteSubscription(subscription, organization, props.actions);
+  };
+
+  return (
+    <div className="card">
+      <header className="card-header">
+        <p className="card-header-title">{subscription.plan.name}</p>
+      </header>
+
+      <div className="card-content">
+        <div className="content">
+          <div className="media-content">
+            <div className="content">
+              Lorem ipsum about the subscription, maybe a link, not sure what
+              might go here.
+            </div>
+          </div>
+        </div>
+      </div>
+      <footer className="card-footer">
+        <a onClick={removeSubscription} className="card-footer-item">
+          Remove
+        </a>
+      </footer>
+    </div>
+  );
+};
+
+export default SubscriptionCard;


### PR DESCRIPTION
**Note: this requires working with the squarelet API at [feature/ids-for-subs-and-plans](https://github.com/jacqui/squarelet/tree/feature/ids-for-subs-and-plans)**

**Also note: I decided to break out the free plans work from the paid ones, as I anticipate the paid plan subscriptions will involve a bit of code. Hoping this makes the PR review process easier.**

This PR addresses issue #13, adding functionality to the Manage Organization page:

* edit the organization name
* make it private
* list your current subscriptions
* remove one or more subscriptions
* subscribe to one or more additional plans, provided they are free

I've moved plans and subscriptions to card components on the manage organization page. Plans have a "subscribe" button, subscriptions have a "remove" button to unsubscribe.

I should note that I still have trouble with the API on many of these requests, but I'm hoping to clarify how this should all work when we chat with MuckRock tomorrow. I thought I'd get the front-end code pushed anyway.