### PR TITLE
Request an invitation page

### DIFF
--- a/src/invitation/RequestInvitePage.tsx
+++ b/src/invitation/RequestInvitePage.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState, SyntheticEvent } from 'react';
+import { AppActions } from '../store';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { OrganizationState } from '../store/organizations/types';
+import { ensureOrganizations } from '../store/organizations/api';
+import { requestInvitation } from '../store/invitations/api';
+import { Link } from 'react-router-dom';
+
+interface RequestInvitePageProps {
+  actions: AppActions;
+  organization: number;
+  organizations: OrganizationState;
+}
+
+export const RequestInvitePage: React.FC<RequestInvitePageProps> = (
+  props: RequestInvitePageProps
+) => {
+  let [errors, setErrors] = useState<any>({});
+  let [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    ensureOrganizations(props.actions, props.organizations);
+  }, [props.actions, props.organizations]);
+
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  // the list of orgs in the props is filled in by ensureOrganizations
+  // the following line pulls the org out of the map by matching the prop 'organization' (an ID)
+  let organization = props.organizations.organizations[props.organization];
+
+  function handleFormSubmit(event: SyntheticEvent) {
+    event.preventDefault();
+
+    requestInvitation(organization.uuid, props.actions).then(status => {
+      if (status.ok) {
+        setSaved(true);
+        setErrors({});
+      } else {
+        setErrors(status.body);
+      }
+    });
+  }
+
+  if (saved) {
+    return (
+      <div className="notification is-success">
+        <strong>Success!</strong> You've requested an invite to the{' '}
+        {organization.name} organization.
+        <p>
+          <Link to="/profile">Return to your profile</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      Request an invite to join the organization <b>{organization.name}</b>
+      <form className="limited-width" onSubmit={handleFormSubmit}>
+        <button className="button is-primary" type="submit">
+          Send request
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -8,6 +8,7 @@ import { OrganizationsList } from './OrganizationsList';
 import { OrganizationCreatePage } from './OrganizationCreatePage';
 import { InvitationPage } from '../invitation/InvitationPage';
 import { InvitePage } from '../invitation/InvitePage';
+import { RequestInvitePage } from '../invitation/RequestInvitePage';
 
 export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
@@ -60,6 +61,17 @@ export const getRoutes = (props: AppProps) => {
       path="/organizations/:id/invite"
       render={routeProps => (
         <InvitePage {...props} organization={routeProps.match.params.id} />
+      )}
+      {...authProps}
+    />,
+    <ProtectedRoute
+      exact
+      path="/organizations/:id/request"
+      render={routeProps => (
+        <RequestInvitePage
+          {...props}
+          organization={routeProps.match.params.id}
+        />
       )}
       {...authProps}
     />

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -213,6 +213,27 @@ export const createInvitation = (
       })
     );
 
+export const requestInvitation = (
+  organization_id: string,
+  actions: AppActions
+) =>
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${organization_id}/invitations/`,
+    JSON_POST({
+      request: true
+    })
+  )
+    .then(checkAuth(actions)) // Necessary
+    .then(response =>
+      validate(response, (status: ItemizedResponse) => {
+        actions.upsertInvitation(status.body as Invitation);
+        notify(
+          '[TODO remove this?] Successfully requested an invite.',
+          'success'
+        );
+      })
+    );
+
 export const deleteInvitation = (invitation: Invitation, actions: AppActions) =>
   cfetch(
     `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${invitation.organization}/invitations/${invitation.user}`,


### PR DESCRIPTION
This PR adds an invite request feature (issue #31), allowing a logged-in user to request joining an organization.

So now we have the following functionality around joining an org:

* an organization admin can invite someone to join at `/organizations/{organization_id}/invite`
* a logged-in presspass user can request to join an organization at `/organizations/{organization_id}/request`
* someone can respond to an invitation and accept or reject by following the link in their email, which currently goes to `/organizations/{invitation_id}/invitation`