### PR TITLE
Search organizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4086,6 +4086,11 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.0.tgz",
+      "integrity": "sha512-8P1cDi8ebZyDxUyUprBXwidoEtiQAawYPGvpfb+Dg0G6JrQ+VozwOmm91xYC0vAv1+0VmLehEPb+isg4BGUFfA=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react-redux": "^7.1.5",
     "@types/react-router-dom": "^5.1.2",
     "bulma": "^0.8.0",
+    "date-fns": "^2.11.0",
     "js-cookie": "^2.2.1",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { format } from 'date-fns';
+
 import { Organization } from '../store/organizations/types';
 import { Link } from 'react-router-dom';
 
@@ -10,27 +12,42 @@ const OrganizationCard: React.FC<OrganizationCardProps> = (
   props: OrganizationCardProps
 ) => {
   let organization = props.organization;
+  let avatar;
+  if (typeof organization.avatar === 'string') {
+    avatar = organization.avatar;
+    // avatar = URL.createObjectURL(organization.avatar);
+  }
+  var formattedDate = format(
+    new Date(organization.updated_at),
+    'd MMM yyyy H:mma'
+  );
+
   return (
-    <Link className="box" to={'/organizations/' + organization.uuid}>
-      <h5 className="title is-size-5">{organization.name}</h5>
-      <div className="field is-grouped is-grouped-multiline">
-        <div className="control">
-          <dl>
-            <dt>ID:</dt>
-            <dd>{organization.uuid}</dd>
-
-            <dt>Private?</dt>
-            <dd>{organization.private}</dd>
-
-            <dt>Max users:</dt>
-            <dd>{organization.max_users}</dd>
-
-            <dt>Updated at:</dt>
-            <dd>{organization.updated_at}</dd>
-          </dl>
+    <div className="box">
+      <article className="media">
+        <div className="media-left">
+          <figure className="image is-64x64">
+            <img src={avatar} />
+          </figure>
         </div>
-      </div>
-    </Link>
+        <div className="media-content">
+          <div className="content">
+            <Link to={'/organizations/' + organization.uuid}>
+              <h5 className="title is-size-5">{organization.name}</h5>
+            </Link>
+            <p>
+              This is a {organization.private ? 'private' : 'public'}{' '}
+              organization with a max user count of{' '}
+              <code>{organization.max_users}</code>.
+              <br />
+              <strong>Updated:</strong> {formattedDate}
+              <br />
+              <small className="has-text-grey">{organization.uuid}</small>
+            </p>
+          </div>
+        </div>
+      </article>
+    </div>
   );
 };
 

--- a/src/organization/OrganizationPage.tsx
+++ b/src/organization/OrganizationPage.tsx
@@ -6,8 +6,10 @@ import { AppProps } from '../store';
 import OrganizationCard from './OrganizationCard';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { Link } from 'react-router-dom';
+import { MembershipState } from '../store/memberships/types';
 
 interface OrganizationPageProps extends AppProps {
+  memberships: MembershipState;
   organization: string;
   organizations: OrganizationState;
   actions: AppActions;
@@ -24,7 +26,11 @@ export const OrganizationPage = (props: OrganizationPageProps) => {
   let organization = props.organizations.organizations[props.organization];
   return (
     <section className="organization-page">
-      <OrganizationCard organization={organization} />
+      <OrganizationCard
+        actions={props.actions}
+        memberships={props.memberships}
+        organization={organization}
+      />
       <p>
         Organization page (id {organization.uuid}) (
         <Link to={`./${organization.uuid}/manage`}>manage</Link>)

--- a/src/organization/OrganizationsList.tsx
+++ b/src/organization/OrganizationsList.tsx
@@ -21,7 +21,13 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
     async function fetchData() {
       await ensureOrganizations(props.actions, props.organizations);
       if (props.organizations.hydrated) {
-        setItems(Object.values(props.organizations.organizations));
+        setItems(
+          Object.values(props.organizations.organizations).filter(
+            (organization: Organization) => {
+              return !organization.private && !organization.individual;
+            }
+          )
+        );
       }
     }
     fetchData();
@@ -32,7 +38,11 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
   }
 
   const filterList = event => {
-    let initialItems = Object.values(props.organizations.organizations);
+    let initialItems = Object.values(props.organizations.organizations).filter(
+      (organization: Organization) => {
+        return !organization.private && !organization.individual;
+      }
+    );
     let filteredItems = initialItems.filter(item => {
       return (
         item.name.toLowerCase().search(event.target.value.toLowerCase()) !== -1

--- a/src/organization/OrganizationsList.tsx
+++ b/src/organization/OrganizationsList.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AppActions } from '../store';
 import { OrganizationState, Organization } from '../store/organizations/types';
 import { ensureOrganizations } from '../store/organizations/api';
 import OrganizationCard from './OrganizationCard';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import Field from '../common/Field';
 
 interface OrganizationsListProps {
   actions: AppActions;
@@ -12,18 +14,50 @@ interface OrganizationsListProps {
 export const OrganizationsList: React.FC<OrganizationsListProps> = (
   props: OrganizationsListProps
 ) => {
+  const [items, setItems] = useState(
+    Object.values(props.organizations.organizations)
+  );
   useEffect(() => {
-    ensureOrganizations(props.actions, props.organizations);
+    async function fetchData() {
+      await ensureOrganizations(props.actions, props.organizations);
+      if (props.organizations.hydrated) {
+        setItems(Object.values(props.organizations.organizations));
+      }
+    }
+    fetchData();
   }, [props.actions, props.organizations]);
 
+  if (!props.organizations.hydrated) {
+    return <LoadingPlaceholder />;
+  }
+
+  const filterList = event => {
+    let initialItems = Object.values(props.organizations.organizations);
+    let filteredItems = initialItems.filter(item => {
+      return (
+        item.name.toLowerCase().search(event.target.value.toLowerCase()) !== -1
+      );
+    });
+    setItems(filteredItems);
+  };
   return (
     <div className="organizations">
       <h1 className="title is-size-1">Organizations</h1>
+      <form>
+        <Field label="Search">
+          <input
+            type="text"
+            placeholder="Search"
+            onChange={filterList}
+            className="input"
+          />
+        </Field>
+      </form>
       <div className="columns is-multiline">
-        {Object.values(props.organizations.organizations)
+        {items
           .sort((a, b) => (a.name > b.name ? 1 : -1))
           .map((organization: Organization) => (
-            <div className="column is-4">
+            <div className="column is-4" key={organization.uuid}>
               <OrganizationCard organization={organization} />
             </div>
           ))}

--- a/src/organization/OrganizationsList.tsx
+++ b/src/organization/OrganizationsList.tsx
@@ -2,13 +2,18 @@ import React, { useEffect, useState } from 'react';
 import { AppActions } from '../store';
 import { OrganizationState, Organization } from '../store/organizations/types';
 import { ensureOrganizations } from '../store/organizations/api';
+import { ensureMembershipsForUser } from '../store/memberships/api';
 import OrganizationCard from './OrganizationCard';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import Field from '../common/Field';
+import { MembershipState } from '../store/memberships/types';
+import { UsersState } from '../store/users/types';
 
 interface OrganizationsListProps {
   actions: AppActions;
   organizations: OrganizationState;
+  memberships: MembershipState;
+  users: UsersState;
 }
 
 export const OrganizationsList: React.FC<OrganizationsListProps> = (
@@ -29,9 +34,14 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
           )
         );
       }
+      // load user's memberships list
+      if (props.users.self !== null) {
+        const uuid = props.users.self.uuid;
+        await ensureMembershipsForUser(props.actions, uuid, props.memberships);
+      }
     }
     fetchData();
-  }, [props.actions, props.organizations]);
+  }, [props.actions, props.organizations, props.memberships]);
 
   if (!props.organizations.hydrated) {
     return <LoadingPlaceholder />;
@@ -68,7 +78,11 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
           .sort((a, b) => (a.name > b.name ? 1 : -1))
           .map((organization: Organization) => (
             <div className="column is-4" key={organization.uuid}>
-              <OrganizationCard organization={organization} />
+              <OrganizationCard
+                actions={props.actions}
+                organization={organization}
+                memberships={props.memberships}
+              />
             </div>
           ))}
       </div>

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -16,7 +16,9 @@ export const getRoutes = (props: AppProps) => {
     <ProtectedRoute exact path="/organizations" {...authProps}>
       <OrganizationsList
         actions={props.actions}
+        memberships={props.memberships}
         organizations={props.organizations}
+        users={props.users}
       />
     </ProtectedRoute>,
     <ProtectedRoute


### PR DESCRIPTION
This PR adds a search to the organizations list page (issue #32). It also cleans up the `OrganizationCard` a bit, adding date formatting with [date-fns](https://date-fns.org/) for a nicer display of the last updated at value.

I've added filtering to the listing and searching of organizations to keep private or individual orgs from being included (issue #40).

If you're not already a member of an organization, a "request to join" button will display. If the request is sent successfully, it will be replaced with a "Requested" tag. 