### PR TITLE
Default page changed to entitlements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,10 +60,10 @@ const App = (props: AppProps) => {
           <div className="container">
             <Switch>
               <ProtectedRoute exact path="/" {...authProps}>
-                <Redirect to="/clients" />
+                <Redirect to="/entitlements" />
               </ProtectedRoute>
               <ProtectedRoute exact path="/index.html" {...authProps}>
-                <Redirect to="/clients" />
+                <Redirect to="/entitlements" />
               </ProtectedRoute>
               {authRoutes(props).map(route => route)}
               {clientsRoutes(props).map(route => route)}

--- a/src/entitlements/EntitlementsList.tsx
+++ b/src/entitlements/EntitlementsList.tsx
@@ -1,31 +1,35 @@
-import React, { useEffect } from "react";
+import React, { useEffect } from 'react';
 import { AppActions } from '../store';
-import { ensureEntitlements } from "../store/entitlements/api";
-import EntitlementCard from "./EntitlementCard";
-import { EntitlementState, Entitlement } from "../store/entitlements/types";
+import { ensureEntitlements } from '../store/entitlements/api';
+import EntitlementCard from './EntitlementCard';
+import { EntitlementState, Entitlement } from '../store/entitlements/types';
 
 interface EntitlementsListProps {
   actions: AppActions;
   entitlements: EntitlementState;
 }
 
-const EntitlementsList: React.FC<EntitlementsListProps> = (props: EntitlementsListProps) => {
+const EntitlementsList: React.FC<EntitlementsListProps> = (
+  props: EntitlementsListProps
+) => {
   useEffect(() => {
     ensureEntitlements(props.actions, props.entitlements);
   }, [props.actions, props.entitlements]);
 
   return (
     <div className="entitlements">
-    <h1 className="title is-size-1">Entitlements</h1>
-    <div className="columns is-multiline">
-    {Object.values(props.entitlements.entitlements).map((entitlement: Entitlement) => (
-      <div className="column is-4">
-        <EntitlementCard entitlement={entitlement} />
+      <h1 className="title is-size-1">Entitlements</h1>
+      <div className="columns is-multiline">
+        {Object.values(props.entitlements.entitlements).map(
+          (entitlement: Entitlement) => (
+            <div key={entitlement.id} className="column is-4">
+              <EntitlementCard entitlement={entitlement} />
+            </div>
+          )
+        )}
       </div>
-    ))}
     </div>
-    </div>
-  )
-}
+  );
+};
 
 export default EntitlementsList;


### PR DESCRIPTION
This PR changes the default page for users from `/clients` to `/entitlements` (issue #34). 

It also includes a small change setting the `key` of each entitlement div as I noticed it was missing.