### PR TITLE
Minor entitlement & organization cleanup

### DIFF
--- a/src/entitlements/EntitlementCard.tsx
+++ b/src/entitlements/EntitlementCard.tsx
@@ -10,25 +10,26 @@ const EntitlementCard: React.FC<EntitlementCardProps> = (
 ) => {
   let entitlement = props.entitlement;
   return (
-    <a
-      className="box"
-      target="_blank"
-      rel="noopener noreferrer"
-      href={entitlement.client.website_url}
-    >
-      <h5 className="title is-size-5">{entitlement.name}</h5>
-      <div className="field is-grouped is-grouped-multiline">
-        <div className="control">
-          <div className="tags has-addons">
-            <span className="tag is-dark">Name</span>
-            <span className="tag is-info">{entitlement.name}</span>
-          </div>
+    <div className="card">
+      <header className="card-header">
+        <p className="card-header-title">{entitlement.name}</p>
+      </header>
+      <div className="card-content">
+        <div className="content">
+          <strong>Client:</strong> {entitlement.client.name}
+          <br />
+          <strong>Link:</strong>{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={entitlement.client.website_url}
+          >
+            {entitlement.client.website_url}
+          </a>
+          <p>{entitlement.description}</p>
         </div>
       </div>
-      <div className="content">
-        <p>{entitlement.description}</p>
-      </div>
-    </a>
+    </div>
   );
 };
 

--- a/src/entitlements/EntitlementsList.tsx
+++ b/src/entitlements/EntitlementsList.tsx
@@ -1,31 +1,35 @@
-import React, { useEffect } from "react";
+import React, { useEffect } from 'react';
 import { AppActions } from '../store';
-import { ensureEntitlements } from "../store/entitlements/api";
-import EntitlementCard from "./EntitlementCard";
-import { EntitlementState, Entitlement } from "../store/entitlements/types";
+import { ensureEntitlements } from '../store/entitlements/api';
+import EntitlementCard from './EntitlementCard';
+import { EntitlementState, Entitlement } from '../store/entitlements/types';
 
 interface EntitlementsListProps {
   actions: AppActions;
   entitlements: EntitlementState;
 }
 
-const EntitlementsList: React.FC<EntitlementsListProps> = (props: EntitlementsListProps) => {
+const EntitlementsList: React.FC<EntitlementsListProps> = (
+  props: EntitlementsListProps
+) => {
   useEffect(() => {
     ensureEntitlements(props.actions, props.entitlements);
   }, [props.actions, props.entitlements]);
 
   return (
     <div className="entitlements">
-    <h1 className="title is-size-1">Entitlements</h1>
-    <div className="columns is-multiline">
-    {Object.values(props.entitlements.entitlements).map((entitlement: Entitlement) => (
-      <div className="column is-4">
-        <EntitlementCard entitlement={entitlement} />
+      <h1 className="title is-size-1">Entitlements</h1>
+      <div className="columns is-multiline">
+        {Object.values(props.entitlements.entitlements).map(
+          (entitlement: Entitlement) => (
+            <div className="column is-4">
+              <EntitlementCard entitlement={entitlement} />
+            </div>
+          )
+        )}
       </div>
-    ))}
     </div>
-    </div>
-  )
-}
+  );
+};
 
 export default EntitlementsList;

--- a/src/organization/OrganizationPage.tsx
+++ b/src/organization/OrganizationPage.tsx
@@ -3,6 +3,7 @@ import { AppActions } from '../store';
 import { OrganizationState } from '../store/organizations/types';
 import { ensureOrganizations } from '../store/organizations/api';
 import { AppProps } from '../store';
+import OrganizationCard from './OrganizationCard';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { Link } from 'react-router-dom';
 
@@ -23,23 +24,10 @@ export const OrganizationPage = (props: OrganizationPageProps) => {
   let organization = props.organizations.organizations[props.organization];
   return (
     <section className="organization-page">
-      <p className="subtitle">PressPass News Organization</p>
-      <h1 className="title is-size-1">{organization.name}</h1>
-      <table className="table">
-        <tbody>
-          <tr>
-            <td className="has-text-weight-bold">Name</td>
-            <td>{organization.name}</td>
-          </tr>
-          <tr>
-            <td className="has-text-weight-bold">Avatar</td>
-            <td>{organization.avatar}</td>
-          </tr>
-        </tbody>
-      </table>
+      <OrganizationCard organization={organization} />
       <p>
         Organization page (id {organization.uuid}) (
-        <Link to={`./${organization.id}/manage`}>manage</Link>)
+        <Link to={`./${organization.uuid}/manage`}>manage</Link>)
       </p>
     </section>
   );

--- a/src/store/entitlements/api.ts
+++ b/src/store/entitlements/api.ts
@@ -1,4 +1,4 @@
-import { AppActions } from "..";
+import { AppActions } from '..';
 import {
   checkAuth,
   cfetch,
@@ -9,34 +9,43 @@ import {
   PATCH,
   POST,
   DELETE
-} from "../../utils";
-import { Entitlement, EntitlementState } from "./types";
+} from '../../utils';
+import { Entitlement, EntitlementState } from './types';
 
 const serializeEntitlement = (entitlement: Entitlement) => ({
   id: entitlement.id,
-  name: entitlement.name || "",
-  description: entitlement.description || "",
+  name: entitlement.name || '',
+  description: entitlement.description || ''
   // Explicitly setting each field is necessary here, because
   // not all of the fields in entitlement are write-available, and
   // including them in the request would result in a 400 response.
 });
 
 export const fetchEntitlements = (actions: AppActions) =>
-  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/`, GET)
+  cfetch(
+    `${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/?expand=client`,
+    GET
+  )
     .then(checkAuth(actions))
     .then(response => response.json())
     .then(data => Promise.all([actions.upsertEntitlements(data.results)]))
     .catch(error => {
-      console.error("API Error fetchEntitlements", error, error.code);
+      console.error('API Error fetchEntitlements', error, error.code);
     });
 
-export const ensureEntitlements = (actions: AppActions, entitlements: EntitlementState) => {
+export const ensureEntitlements = (
+  actions: AppActions,
+  entitlements: EntitlementState
+) => {
   if (!entitlements.hydrated) {
     return fetchEntitlements(actions);
   }
 };
 
-export const updateEntitlement = (entitlement: Entitlement, actions: AppActions) => {
+export const updateEntitlement = (
+  entitlement: Entitlement,
+  actions: AppActions
+) => {
   let formData = new FormData();
   let packagedEntitlement: any = serializeEntitlement(entitlement);
   for (let key of Object.keys(packagedEntitlement)) {
@@ -50,12 +59,15 @@ export const updateEntitlement = (entitlement: Entitlement, actions: AppActions)
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
         actions.upsertEntitlement(status.body as Entitlement);
-        notify(`Successfully updated ${entitlement.name}.`, "success");
+        notify(`Successfully updated ${entitlement.name}.`, 'success');
       })
     );
 };
 
-export const createEntitlement = (entitlement: Entitlement, actions: AppActions) => {
+export const createEntitlement = (
+  entitlement: Entitlement,
+  actions: AppActions
+) => {
   let formData = new FormData();
   let packagedEntitlement: any = serializeEntitlement(entitlement);
   for (let key of Object.keys(packagedEntitlement)) {
@@ -71,13 +83,16 @@ export const createEntitlement = (entitlement: Entitlement, actions: AppActions)
       .then(response =>
         validate(response, (status: ItemizedResponse) => {
           actions.upsertEntitlement(status.body as Entitlement);
-          notify(`Successfully created ${entitlement.name}.`, "success");
+          notify(`Successfully created ${entitlement.name}.`, 'success');
         })
       )
   );
 };
 
-export const deleteEntitlement = (entitlement: Entitlement, actions: AppActions) =>
+export const deleteEntitlement = (
+  entitlement: Entitlement,
+  actions: AppActions
+) =>
   cfetch(
     `${process.env.REACT_APP_SQUARELET_API_URL}/entitlements/${entitlement.id}`,
     DELETE
@@ -86,6 +101,6 @@ export const deleteEntitlement = (entitlement: Entitlement, actions: AppActions)
     .then(response =>
       validate(response, () => {
         actions.deleteEntitlement(entitlement);
-        notify(`Successfully deleted ${entitlement.name}.`, "success");
+        notify(`Successfully deleted ${entitlement.name}.`, 'success');
       })
     );


### PR DESCRIPTION
While reviewing the site for purposes of cleaning up the navigation, I noticed that the entitlements list needed a bit of love:

* entitlement card components are now actual bulma cards (looks better)
* api call for entitlements now expands client data (allows us to link entitlement & display name)

And I also noticed the OrganizationPage was looking bad, and because it didn't have any additional info than you find in the OrganizationCard, I decided to have it render that card component (less repeating of code ftw) instead.
