### PR TITLE
Manage member requests

### DIFF
--- a/src/invitation/InvitationCard.tsx
+++ b/src/invitation/InvitationCard.tsx
@@ -28,7 +28,7 @@ const InvitationActions: React.FC<InvitationCardProps> = (
   let showInvitationIsHandledStatus = accepted || rejected;
 
   const onAcceptClick = () => {
-    acceptInvitation(invitation, props.actions).then(status => {
+    acceptInvitation(invitation, props.actions, 'invitation').then(status => {
       if (status.ok) {
         console.log('successfully accepted the invite');
         setSaved(true);
@@ -39,7 +39,7 @@ const InvitationActions: React.FC<InvitationCardProps> = (
   };
 
   const onRejectClick = () => {
-    rejectInvitation(invitation, props.actions).then(status => {
+    rejectInvitation(invitation, props.actions, 'invitation').then(status => {
       if (status.ok) {
         console.log('successfully rejected the invite');
         setSaved(true);

--- a/src/invitation/InvitationRequestCard.tsx
+++ b/src/invitation/InvitationRequestCard.tsx
@@ -32,41 +32,44 @@ const InvitationRequestActions: React.FC<InvitationRequestActionProps> = (
   let showActionButtons = !accepted && !rejected;
 
   const onAcceptClick = () => {
-    acceptInvitation(invitation, props.actions).then(status => {
-      if (status.ok) {
-        console.log('successfully accepted the membership request');
-        setSaved(true);
-      } else {
-        setErrors(status.body);
+    acceptInvitation(invitation, props.actions, 'membership request').then(
+      status => {
+        if (status.ok) {
+          setSaved(true);
+        } else {
+          setErrors(status.body);
+        }
       }
-    });
+    );
   };
 
   const onRejectClick = () => {
-    rejectInvitation(invitation, props.actions).then(status => {
-      if (status.ok) {
-        console.log('successfully rejected the membership request');
-        setSaved(true);
-      } else {
-        setErrors(status.body);
+    rejectInvitation(invitation, props.actions, 'membership request').then(
+      status => {
+        if (status.ok) {
+          console.log('successfully rejected the membership request');
+          setSaved(true);
+        } else {
+          setErrors(status.body);
+        }
       }
-    });
+    );
   };
 
-  if (saved) {
-    return <Redirect to={`/profile`} />;
-  }
+  // if (saved) {
+  //   return <Redirect to={`/profile`} />;
+  // }
 
   if (showActionButtons) {
     return (
-      <div className="buttons">
-        <button onClick={onAcceptClick} className="button is-success">
-          accept
-        </button>
-        <button onClick={onRejectClick} className="button is-danger">
-          reject
-        </button>
-      </div>
+      <footer className="card-footer">
+        <a onClick={onAcceptClick} className="card-footer-item">
+          Accept
+        </a>
+        <a onClick={onRejectClick} className="card-footer-item">
+          Reject
+        </a>
+      </footer>
     );
   } else {
     return (
@@ -96,35 +99,23 @@ const InvitationRequestCard: React.FC<InvitationRequestCardProps> = (
   props: InvitationRequestCardProps
 ) => {
   let invitation = props.invitation;
-  useEffect(() => {
-    async function fetchData() {
-      await fetchUser(props.actions, invitation.user);
-    }
-    fetchData();
-  }, []);
-
-  if (props.users.user == null) {
-    return <LoadingPlaceholder />;
-  }
 
   var formattedDate = format(
     new Date(invitation.created_at),
     'd MMM yyyy H:mma'
   );
   return (
-    <div key={invitation.user} className="box">
-      <h5 className="title is-size-5">
-        {props.users.user.name} requested membership
-      </h5>
-      <div>
-        <InvitationRequestActions
-          actions={props.actions}
-          invitation={invitation}
-        />
-        <p>
-          <strong>Requested at:</strong> <small>{formattedDate}</small>
-        </p>
+    <div key={invitation.user_id} className="card">
+      <div className="card-content">
+        <div className="content">
+          {invitation.user.email} requested membership at{' '}
+          <small>{formattedDate}</small>.
+        </div>
       </div>
+      <InvitationRequestActions
+        actions={props.actions}
+        invitation={invitation}
+      />
     </div>
   );
 };

--- a/src/invitation/InvitationRequestCard.tsx
+++ b/src/invitation/InvitationRequestCard.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import { AppActions } from '../store';
+import { Invitation } from '../store/invitations/types';
+import { fetchUser } from '../store/users/api';
+import { acceptInvitation, rejectInvitation } from '../store/invitations/api';
+import { Redirect } from 'react-router';
+import { User, UsersState } from '../store/users/types';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { format } from 'date-fns';
+
+interface InvitationRequestCardProps {
+  actions: AppActions;
+  invitation: Invitation;
+  users: UsersState;
+}
+
+interface InvitationRequestActionProps {
+  actions: AppActions;
+  invitation: Invitation;
+}
+
+const InvitationRequestActions: React.FC<InvitationRequestActionProps> = (
+  props: InvitationRequestActionProps
+) => {
+  let [saved, setSaved] = useState(false);
+  let [errors, setErrors] = useState({});
+  let accepted = !!props.invitation.accepted_at;
+  let rejected = !!props.invitation.rejected_at;
+  let invitation = props.invitation;
+
+  // this is an open request for membership and the org manager can accept or reject
+  let showActionButtons = !accepted && !rejected;
+
+  const onAcceptClick = () => {
+    acceptInvitation(invitation, props.actions).then(status => {
+      if (status.ok) {
+        console.log('successfully accepted the membership request');
+        setSaved(true);
+      } else {
+        setErrors(status.body);
+      }
+    });
+  };
+
+  const onRejectClick = () => {
+    rejectInvitation(invitation, props.actions).then(status => {
+      if (status.ok) {
+        console.log('successfully rejected the membership request');
+        setSaved(true);
+      } else {
+        setErrors(status.body);
+      }
+    });
+  };
+
+  if (saved) {
+    return <Redirect to={`/profile`} />;
+  }
+
+  if (showActionButtons) {
+    return (
+      <div className="buttons">
+        <button onClick={onAcceptClick} className="button is-success">
+          accept
+        </button>
+        <button onClick={onRejectClick} className="button is-danger">
+          reject
+        </button>
+      </div>
+    );
+  } else {
+    return (
+      <div>
+        {accepted ? (
+          <p>
+            <strong>Accepted at:</strong>{' '}
+            <small>{invitation.accepted_at}</small>
+          </p>
+        ) : (
+          ''
+        )}
+        {rejected ? (
+          <p>
+            <strong>Rejected at:</strong>{' '}
+            <small>{invitation.rejected_at}</small>
+          </p>
+        ) : (
+          ''
+        )}
+      </div>
+    );
+  }
+};
+
+const InvitationRequestCard: React.FC<InvitationRequestCardProps> = (
+  props: InvitationRequestCardProps
+) => {
+  let invitation = props.invitation;
+  useEffect(() => {
+    async function fetchData() {
+      await fetchUser(props.actions, invitation.user);
+    }
+    fetchData();
+  }, []);
+
+  if (props.users.user == null) {
+    return <LoadingPlaceholder />;
+  }
+
+  var formattedDate = format(
+    new Date(invitation.created_at),
+    'd MMM yyyy H:mma'
+  );
+  return (
+    <div key={invitation.user} className="box">
+      <h5 className="title is-size-5">
+        {props.users.user.name} requested membership
+      </h5>
+      <div>
+        <InvitationRequestActions
+          actions={props.actions}
+          invitation={invitation}
+        />
+        <p>
+          <strong>Requested at:</strong> <small>{formattedDate}</small>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default InvitationRequestCard;

--- a/src/invitation/InvitationsList.tsx
+++ b/src/invitation/InvitationsList.tsx
@@ -7,8 +7,8 @@ import InvitationRequestCard from '../invitation/InvitationRequestCard';
 
 interface InvitationsListProps {
   actions: AppActions;
-  organization: Organization;
   invitations: InvitationState;
+  organization: Organization;
   users: UsersState;
 }
 
@@ -17,7 +17,14 @@ const InvitationsList: React.FC<InvitationsListProps> = (
 ) => {
   let organization = props.organization;
   let invitations = Object.values(props.invitations.invitations).filter(
-    invitation => invitation.request
+    invitation => {
+      if (
+        invitation.request &&
+        invitation.accepted_at === null &&
+        invitation.rejected_at === null
+      )
+        return invitation;
+    }
   );
 
   if (invitations.length === 0) {

--- a/src/invitation/InvitationsList.tsx
+++ b/src/invitation/InvitationsList.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Organization } from '../store/organizations/types';
+import { UsersState } from '../store/users/types';
+import { Invitation, InvitationState } from '../store/invitations/types';
+import { AppActions } from '../store';
+import InvitationRequestCard from '../invitation/InvitationRequestCard';
+
+interface InvitationsListProps {
+  actions: AppActions;
+  organization: Organization;
+  invitations: InvitationState;
+  users: UsersState;
+}
+
+const InvitationsList: React.FC<InvitationsListProps> = (
+  props: InvitationsListProps
+) => {
+  let organization = props.organization;
+  let invitations = Object.values(props.invitations.invitations).filter(
+    invitation => invitation.request
+  );
+
+  if (invitations.length === 0) {
+    return (
+      <div className="invitations">
+        <p>{props.organization.name} has no open requests for memberships.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="columns invitations">
+      {invitations.map((invitation: Invitation) => (
+        <div className="column is-4" key={invitation.uuid}>
+          <InvitationRequestCard
+            actions={props.actions}
+            key={invitation.uuid}
+            invitation={invitation}
+            users={props.users}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+export default InvitationsList;

--- a/src/membership/ManageButton.tsx
+++ b/src/membership/ManageButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Membership } from '../store/memberships/types';
+
+interface ManageButtonProps {
+  membership: Membership;
+}
+const ManageButton: React.FC<ManageButtonProps> = (
+  props: ManageButtonProps
+) => {
+  if (!props.membership.admin) {
+    return null;
+  }
+  return (
+    <Link
+      to={'/organizations/' + props.membership.organization.uuid + '/manage'}
+      className="card-footer-item"
+    >
+      Manage
+    </Link>
+  );
+};
+
+export default ManageButton;

--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { AppActions } from '../store';
-import { Membership } from '../store/memberships/types';
 import { Link } from 'react-router-dom';
+import { AppActions } from '../store';
 import { deleteMembership } from '../store/memberships/api';
+import { Membership } from '../store/memberships/types';
+import ManageButton from './ManageButton';
 
 interface MembershipCardProps {
   membership: Membership;
@@ -39,25 +40,6 @@ const InviteButton: React.FC<InviteButtonProps> = (
       className="card-footer-item"
     >
       Invite
-    </Link>
-  );
-};
-
-interface ManageButtonProps {
-  membership: Membership;
-}
-const ManageButton: React.FC<ManageButtonProps> = (
-  props: ManageButtonProps
-) => {
-  if (!props.membership.admin) {
-    return null;
-  }
-  return (
-    <Link
-      to={'/organizations/' + props.membership.organization.uuid + '/manage'}
-      className="card-footer-item"
-    >
-      Manage
     </Link>
   );
 };

--- a/src/organization/ManageOrganizationPage.tsx
+++ b/src/organization/ManageOrganizationPage.tsx
@@ -9,14 +9,17 @@ import {
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { AppProps } from '../store';
 import { Link, Redirect } from 'react-router-dom';
+import { ensureInvitationsForOrganization } from '../store/invitations/api';
 import { ensurePlansForOrganization } from '../store/plans/api';
 import OrganizationForm from './OrganizationForm';
 import { ensureSubscriptionsForOrganization } from '../store/subscriptions/api';
 import { SubscriptionState } from '../store/subscriptions/types';
 import { UsersState } from '../store/users/types';
+import { InvitationState } from '../store/invitations/types';
 
 interface ManageOrganizationPageProps extends AppProps {
   actions: AppActions;
+  invitations: InvitationState;
   organization: string;
   organizations: OrganizationState;
   plans: PlanState;
@@ -29,6 +32,11 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
     async function fetchData() {
       await ensureOrganizations(props.actions, props.organizations);
 
+      await ensureInvitationsForOrganization(
+        props.actions,
+        props.organization,
+        props.invitations
+      );
       await ensurePlansForOrganization(
         props.actions,
         props.organization,
@@ -43,6 +51,7 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
     fetchData();
   }, [
     props.actions,
+    props.invitations,
     props.organization,
     props.organizations,
     props.plans,
@@ -54,6 +63,7 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
 
   if (
     !props.organizations.hydrated ||
+    !props.invitations.hydrated ||
     !props.plans.hydrated ||
     !props.subscriptions.hydrated
   ) {
@@ -82,6 +92,7 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
         <OrganizationForm
           actions={props.actions}
           errors={errors}
+          invitations={props.invitations}
           onSubmit={handleSubmit}
           organization={organization}
           plans={props.plans}

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -44,6 +44,17 @@ const OrganizationCardNav: React.FC<OrganizationCardProps> = (
   }
   let userIsMember = props.organization.uuid in props.memberships.memberships;
   if (userIsMember) {
+    let userIsAdmin =
+      props.memberships.memberships[props.organization.uuid].admin;
+    if (userIsAdmin) {
+      return (
+        <nav className="level is-mobile">
+          <div className="level-left">
+            <span className="tag is-success">Admin</span>
+          </div>
+        </nav>
+      );
+    }
     return (
       <nav className="level is-mobile">
         <div className="level-left">

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+
+import { requestInvitation } from '../store/invitations/api';
+
+import { AppActions } from '../store';
+import { Organization } from '../store/organizations/types';
+import { MembershipState } from '../store/memberships/types';
 
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
-import { Organization } from '../store/organizations/types';
-import { Link } from 'react-router-dom';
-import { MembershipState } from '../store/memberships/types';
-import { requestInvitation } from '../store/invitations/api';
-import { AppActions } from '../store';
+import ManageButton from '../membership/ManageButton';
 
 interface OrganizationCardProps {
   actions: AppActions;
@@ -44,15 +47,18 @@ const OrganizationCardNav: React.FC<OrganizationCardProps> = (
   }
   let userIsMember = props.organization.uuid in props.memberships.memberships;
   if (userIsMember) {
-    let userIsAdmin =
-      props.memberships.memberships[props.organization.uuid].admin;
+    let membership = props.memberships.memberships[props.organization.uuid];
+    let userIsAdmin = membership.admin;
     if (userIsAdmin) {
       return (
-        <nav className="level is-mobile">
-          <div className="level-left">
-            <span className="tag is-success">Admin</span>
-          </div>
-        </nav>
+        <div>
+          <nav className="level is-mobile">
+            <div className="level-left">
+              <span className="tag is-success">Admin</span>
+            </div>
+            <ManageButton membership={membership} />
+          </nav>
+        </div>
       );
     }
     return (

--- a/src/organization/OrganizationCreatePage.tsx
+++ b/src/organization/OrganizationCreatePage.tsx
@@ -8,6 +8,7 @@ import { UsersState } from '../store/users/types';
 
 interface OrganizationCreatePageProps {
   actions: AppActions;
+  invitations?: any;
   plans?: any;
   subscriptions?: any;
   users: UsersState;
@@ -52,6 +53,7 @@ export const OrganizationCreatePage: React.FC<OrganizationCreatePageProps> = (
         <OrganizationForm
           actions={props.actions}
           errors={errors}
+          invitations={props.invitations}
           onSubmit={handleSubmit}
           organization={organization}
           plans={props.plans}

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -5,20 +5,23 @@ import React, { useState, SyntheticEvent } from 'react';
 import { Organization } from '../store/organizations/types';
 import Field from '../common/Field';
 import { Plan, PlanState } from '../store/plans/types';
+import { InvitationState } from '../store/invitations/types';
 import { SubscriptionState } from '../store/subscriptions/types';
 import { AppActions } from '../store';
+import InvitationsList from '../invitation/InvitationsList';
 import PlansList from '../plans/PlansList';
 import SubscriptionsList from '../subscriptions/SubscriptionsList';
 import { UsersState } from '../store/users/types';
 
 interface OrganizationFormProps {
   actions: AppActions;
+  errors: any;
+  invitations: InvitationState;
+  onSubmit: (parameter: Organization) => void;
   organization: Organization;
   plans: PlanState;
   subscriptions: SubscriptionState;
   users: UsersState;
-  onSubmit: (parameter: Organization) => void;
-  errors: any;
 }
 
 const OrganizationForm: React.FC<OrganizationFormProps> = (
@@ -89,6 +92,16 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
           This organization's information and membership is not made public
         </label>
       </Field>
+      <hr />
+      <div className="container">
+        <h1 className="title">Membership Requests</h1>
+        <InvitationsList
+          organization={organization}
+          users={props.users}
+          invitations={props.invitations}
+          actions={props.actions}
+        />
+      </div>
       <hr />
       <div className="container">
         <h1 className="title">Subscriptions</h1>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -64,7 +64,7 @@ import { subscriptionReducers } from './subscriptions/reducers';
 import { SubscriptionState } from './subscriptions/types';
 
 // Users
-import { upsertSelfUser } from './users/actions';
+import { upsertSelfUser, upsertUser } from './users/actions';
 import { usersReducers } from './users/reducers';
 import { UsersState } from './users/types';
 
@@ -113,6 +113,7 @@ export interface AppActions {
   upsertEntitlements: typeof upsertEntitlements;
   deleteEntitlement: typeof deleteEntitlement;
   upsertSelfUser: typeof upsertSelfUser;
+  upsertUser: typeof upsertUser;
 }
 
 export interface AppProps {

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -92,7 +92,7 @@ export const fetchInvitationsForOrganization = (
   uuid: string
 ) =>
   cfetch(
-    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/invitations`,
+    `${process.env.REACT_APP_SQUARELET_API_URL}/organizations/${uuid}/invitations/?expand=user`,
     GET
   )
     .then(checkAuth(actions))
@@ -143,7 +143,8 @@ export const updateInvitation = (
 
 export const acceptInvitation = (
   invitation: Invitation,
-  actions: AppActions
+  actions: AppActions,
+  invitationType: string
 ) => {
   let formData = new FormData();
   let packagedInvitation: any = serializeInvitation(invitation);
@@ -160,17 +161,15 @@ export const acceptInvitation = (
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
         actions.upsertInvitation(status.body as Invitation);
-        notify(
-          `Successfully accepted invitation to join organization ${invitation.organization.name}.`,
-          'success'
-        );
+        notify(`Successfully accepted the ${invitationType}`, 'success');
       })
     );
 };
 
 export const rejectInvitation = (
   invitation: Invitation,
-  actions: AppActions
+  actions: AppActions,
+  invitationType: string
 ) => {
   let formData = new FormData();
   let packagedInvitation: any = serializeInvitation(invitation);
@@ -187,10 +186,7 @@ export const rejectInvitation = (
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
         actions.upsertInvitation(status.body as Invitation);
-        notify(
-          `Successfully rejected invitation to join organization ${invitation.organization.name}.`,
-          'success'
-        );
+        notify(`Successfully rejected ${invitationType}`, 'success');
       })
     );
 };

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -99,7 +99,11 @@ export const fetchInvitationsForOrganization = (
     .then(response => response.json())
     .then(data => Promise.all([actions.upsertInvitations(data.results)]))
     .catch(error => {
-      console.error('API Error fetchInvitationsForUser', error, error.code);
+      console.error(
+        'API Error fetchInvitationsForOrganization',
+        error,
+        error.code
+      );
     });
 
 export const ensureInvitationsForOrganization = (

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -22,7 +22,7 @@ export function invitationReducers(
         hydrated: true
       };
       for (let invitation of action.invitations) {
-        incomingObject.invitations[invitation.organization.uuid] = invitation;
+        incomingObject.invitations[invitation.uuid] = invitation;
       }
       return Object.assign({}, state, incomingObject);
     }
@@ -39,7 +39,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      delete incomingObject.invitations[action.invitation.organization.uuid];
+      delete incomingObject.invitations[action.invitation.uuid];
       return Object.assign({}, state, incomingObject);
     }
     default:

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -1,4 +1,5 @@
 import { Organization } from '../organizations/types';
+import { User } from '../users/types';
 
 export const DELETE_INVITATION = 'DELETE_INVITATION';
 export const UPSERT_INVITATION = 'UPSERT_INVITATION';
@@ -7,7 +8,8 @@ export const UPSERT_INVITATIONS = 'UPSERT_INVITATIONS';
 export interface Invitation {
   uuid: number;
   organization: Organization;
-  user: number;
+  user_id: number;
+  user: User;
   email: string;
   request: boolean;
   created_at: Date;

--- a/src/store/users/actions.ts
+++ b/src/store/users/actions.ts
@@ -1,8 +1,15 @@
-import { UPSERT_SELF_USER, User } from "./types";
+import { UPSERT_SELF_USER, UPSERT_USER, User } from './types';
 
 export function upsertSelfUser(self: User) {
   return {
     type: UPSERT_SELF_USER,
-    self: self,
+    self: self
+  };
+}
+
+export function upsertUser(user: User) {
+  return {
+    type: UPSERT_USER,
+    user: user
   };
 }

--- a/src/store/users/api.ts
+++ b/src/store/users/api.ts
@@ -44,3 +44,12 @@ export const updateSelfUser = (user: User, actions: AppActions) => {
       })
     );
 };
+
+export const fetchUser = (actions: AppActions, userid: number) =>
+  cfetch(`${process.env.REACT_APP_SQUARELET_API_URL}/users/${userid}/`, GET)
+    .then(checkAuth(actions))
+    .then(response => response.json())
+    .then(data => Promise.all([actions.upsertUser(data)]))
+    .catch(error => {
+      console.error('API Error fetchUser', error, error.code);
+    });

--- a/src/store/users/reducers.ts
+++ b/src/store/users/reducers.ts
@@ -1,7 +1,13 @@
-import { UsersAction, UPSERT_SELF_USER, UsersState } from "./types";
+import {
+  UsersAction,
+  UPSERT_USER,
+  UPSERT_SELF_USER,
+  UsersState
+} from './types';
 
 const initialState: UsersState = {
-  self: null
+  self: null,
+  user: null
 };
 
 export function usersReducers(
@@ -11,6 +17,9 @@ export function usersReducers(
   switch (action.type) {
     case UPSERT_SELF_USER: {
       return Object.assign({}, state, { self: action.self });
+    }
+    case UPSERT_USER: {
+      return Object.assign({}, state, { user: action.user });
     }
     default:
       return state;

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -1,4 +1,5 @@
 export const UPSERT_SELF_USER = 'UPSERT_SELF_USER';
+export const UPSERT_USER = 'UPSERT_USER';
 
 export interface User {
   name: string;
@@ -15,6 +16,7 @@ export interface User {
 
 export interface UsersState {
   self: User | null;
+  user: User | null;
 }
 
 export interface UpsertSelfUserAction {
@@ -22,4 +24,9 @@ export interface UpsertSelfUserAction {
   self: User;
 }
 
-export type UsersAction = UpsertSelfUserAction;
+export interface UpsertUserAction {
+  type: typeof UPSERT_USER;
+  user: User;
+}
+
+export type UsersAction = UpsertSelfUserAction | UpsertUserAction;


### PR DESCRIPTION
As I was going through the front-end, I realized there was no way for an organization's manager to view or act on the membership requests (aka invitations with request=true) received. 

This PR adds a section of "member requests" to the Manage Organization page, allowing org admins to accept or reject requests.