### PR TITLE
Organize invitation store by organization uuid 

### DIFF
--- a/src/invitation/InvitationList.tsx
+++ b/src/invitation/InvitationList.tsx
@@ -23,11 +23,13 @@ const InvitationList: React.FC<InvitationListProps> = (
     <div>
       <h1 className="title is-size-3">Your Invitations</h1>
       <div className="columns is-multiline">
-        {Object.values(invites).map((invitation: Invitation) => (
-          <div key={invitation.organization.uuid} className="column is-4">
-            <InvitationCard actions={props.actions} invitation={invitation} />
-          </div>
-        ))}
+        {Object.values(invites).map((invitations: Invitation[]) => {
+          invitations.map((invitation: Invitation) => (
+            <div key={invitation.organization.uuid} className="column is-4">
+              <InvitationCard actions={props.actions} invitation={invitation} />
+            </div>
+          ))
+        })}
       </div>
     </div>
   );

--- a/src/invitation/InvitationPage.tsx
+++ b/src/invitation/InvitationPage.tsx
@@ -22,7 +22,7 @@ export const InvitationPage: React.FC<InvitationPageProps> = (
     return <LoadingPlaceholder />;
   }
 
-  let invitation = props.invitations.invitations[props.id];
+  let invitation = Object.values(props.invitations.invitations)[0][0];
 
   return (
     <section className="invitation-page">

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -2,16 +2,18 @@ import React, { useState } from 'react';
 import { format } from 'date-fns';
 
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
-import { Organization } from '../store/organizations/types';
 import { Link } from 'react-router-dom';
+import { Invitation, InvitationState } from '../store/invitations/types';
 import { MembershipState } from '../store/memberships/types';
+import { Organization } from '../store/organizations/types';
 import { requestInvitation } from '../store/invitations/api';
 import { AppActions } from '../store';
 
 interface OrganizationCardProps {
   actions: AppActions;
-  organization: Organization;
+  invitations: InvitationState;
   memberships: MembershipState;
+  organization: Organization;
 }
 
 const OrganizationCardNav: React.FC<OrganizationCardProps> = (
@@ -23,6 +25,7 @@ const OrganizationCardNav: React.FC<OrganizationCardProps> = (
   if (!props.memberships.hydrated) {
     return <LoadingPlaceholder />;
   }
+
   const onRequestClick = () => {
     requestInvitation(props.organization.uuid, props.actions).then(status => {
       if (status.ok) {
@@ -33,21 +36,26 @@ const OrganizationCardNav: React.FC<OrganizationCardProps> = (
       }
     });
   };
-  if (requested) {
-    return (
-      <nav className="level is-mobile">
-        <div className="level-left">
-          <span className="tag is-success">Requested</span>
-        </div>
-      </nav>
-    );
-  }
   let userIsMember = props.organization.uuid in props.memberships.memberships;
   if (userIsMember) {
     return (
       <nav className="level is-mobile">
         <div className="level-left">
           <span className="tag is-info">Member</span>
+        </div>
+      </nav>
+    );
+  }
+  let userRequestedMembership =
+    props.organization.uuid in props.invitations.invitations &&
+    props.invitations.invitations[props.organization.uuid].find(
+      (invite: Invitation) => invite.request
+    );
+  if (userRequestedMembership || requested) {
+    return (
+      <nav className="level is-mobile">
+        <div className="level-left">
+          <span className="tag is-success">Requested</span>
         </div>
       </nav>
     );
@@ -108,6 +116,7 @@ const OrganizationCard: React.FC<OrganizationCardProps> = (
           </div>
           <OrganizationCardNav
             actions={props.actions}
+            invitations={props.invitations}
             memberships={props.memberships}
             organization={organization}
           />

--- a/src/organization/OrganizationPage.tsx
+++ b/src/organization/OrganizationPage.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect } from 'react';
-import { AppActions } from '../store';
-import { OrganizationState } from '../store/organizations/types';
-import { ensureOrganizations } from '../store/organizations/api';
-import { AppProps } from '../store';
-import OrganizationCard from './OrganizationCard';
-import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import { Link } from 'react-router-dom';
+import { AppActions } from '../store';
+import { AppProps } from '../store';
+import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import OrganizationCard from './OrganizationCard';
+import { ensureOrganizations } from '../store/organizations/api';
+import { InvitationState } from '../store/invitations/types';
 import { MembershipState } from '../store/memberships/types';
+import { OrganizationState } from '../store/organizations/types';
 
 interface OrganizationPageProps extends AppProps {
+  invitations: InvitationState;
   memberships: MembershipState;
   organization: string;
   organizations: OrganizationState;
@@ -28,6 +30,7 @@ export const OrganizationPage = (props: OrganizationPageProps) => {
     <section className="organization-page">
       <OrganizationCard
         actions={props.actions}
+        invitations={props.invitations}
         memberships={props.memberships}
         organization={organization}
       />

--- a/src/organization/OrganizationsList.tsx
+++ b/src/organization/OrganizationsList.tsx
@@ -1,18 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import { AppActions } from '../store';
-import { OrganizationState, Organization } from '../store/organizations/types';
-import { ensureOrganizations } from '../store/organizations/api';
+import { ensureInvitationsForUser } from '../store/invitations/api';
 import { ensureMembershipsForUser } from '../store/memberships/api';
+import { ensureOrganizations } from '../store/organizations/api';
 import OrganizationCard from './OrganizationCard';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import Field from '../common/Field';
+import { InvitationState } from '../store/invitations/types';
 import { MembershipState } from '../store/memberships/types';
+import { OrganizationState, Organization } from '../store/organizations/types';
 import { UsersState } from '../store/users/types';
 
 interface OrganizationsListProps {
   actions: AppActions;
-  organizations: OrganizationState;
+  invitations: InvitationState;
   memberships: MembershipState;
+  organizations: OrganizationState;
   users: UsersState;
 }
 
@@ -38,6 +41,7 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
       if (props.users.self !== null) {
         const uuid = props.users.self.uuid;
         await ensureMembershipsForUser(props.actions, uuid, props.memberships);
+        await ensureInvitationsForUser(props.actions, uuid, props.invitations);
       }
     }
     fetchData();
@@ -80,8 +84,9 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
             <div className="column is-4" key={organization.uuid}>
               <OrganizationCard
                 actions={props.actions}
-                organization={organization}
+                invitations={props.invitations}
                 memberships={props.memberships}
+                organization={organization}
               />
             </div>
           ))}

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -16,6 +16,7 @@ export const getRoutes = (props: AppProps) => {
     <ProtectedRoute exact path="/organizations" {...authProps}>
       <OrganizationsList
         actions={props.actions}
+        invitations={props.invitations}
         memberships={props.memberships}
         organizations={props.organizations}
         users={props.users}

--- a/src/store/invitations/actions.ts
+++ b/src/store/invitations/actions.ts
@@ -9,11 +9,13 @@ import {
 } from './types';
 
 export function upsertInvitation(
-  invitation: Invitation
+  invitation: Invitation,
+  organization_id: string
 ): UpsertInvitationAction {
   return {
     type: UPSERT_INVITATION,
-    invitation: invitation
+    invitation: invitation,
+    organization_id: organization_id
   };
 }
 

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -35,7 +35,7 @@ export const fetchInvitation = (actions: AppActions, uuid: string) =>
       data.uuid = uuid; // necessary because the API lacks this ID in the response
       return data;
     })
-    .then(data => Promise.all([actions.upsertInvitation(data)]))
+    .then(data => Promise.all([actions.upsertInvitation(data, uuid)]))
     .catch(error => {
       console.error('API Error fetchInvitation', error, error.code);
     });
@@ -128,7 +128,10 @@ export const updateInvitation = (
     .then(checkAuth(actions))
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
-        actions.upsertInvitation(status.body as Invitation);
+        actions.upsertInvitation(
+          status.body as Invitation,
+          invitation.organization.uuid
+        );
         notify(
           `Successfully updated user ${invitation.user}'s invitation in organization ${invitation.organization}.`,
           'success'
@@ -155,7 +158,10 @@ export const acceptInvitation = (
     .then(checkAuth(actions))
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
-        actions.upsertInvitation(status.body as Invitation);
+        actions.upsertInvitation(
+          status.body as Invitation,
+          invitation.organization.uuid
+        );
         notify(
           `Successfully accepted invitation to join organization ${invitation.organization.name}.`,
           'success'
@@ -182,7 +188,10 @@ export const rejectInvitation = (
     .then(checkAuth(actions))
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
-        actions.upsertInvitation(status.body as Invitation);
+        actions.upsertInvitation(
+          status.body as Invitation,
+          invitation.organization.uuid
+        );
         notify(
           `Successfully rejected invitation to join organization ${invitation.organization.name}.`,
           'success'
@@ -205,7 +214,7 @@ export const createInvitation = (
     .then(checkAuth(actions)) // Necessary
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
-        actions.upsertInvitation(status.body as Invitation);
+        actions.upsertInvitation(status.body as Invitation, organization_id);
         notify('Successfully sent the invitation.', 'success');
       })
     );
@@ -223,7 +232,9 @@ export const requestInvitation = (
     .then(checkAuth(actions)) // Necessary
     .then(response =>
       validate(response, (status: ItemizedResponse) => {
-        actions.upsertInvitation(status.body as Invitation);
+        // this is annoying: the invitation response data doesn't include the organization id :(
+        // so i have to try to reconstruct it here
+        actions.upsertInvitation(status.body as Invitation, organization_id);
         notify('Successfully requested an invite.', 'success');
       })
     );

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -35,7 +35,7 @@ export const fetchInvitation = (actions: AppActions, uuid: string) =>
       data.uuid = uuid; // necessary because the API lacks this ID in the response
       return data;
     })
-    .then(data => Promise.all([actions.upsertInvitation(data, uuid)]))
+    .then(data => Promise.all([actions.upsertInvitation(data, data.organization.uuid)]))
     .catch(error => {
       console.error('API Error fetchInvitation', error, error.code);
     });

--- a/src/store/invitations/api.ts
+++ b/src/store/invitations/api.ts
@@ -35,14 +35,16 @@ export const fetchInvitation = (actions: AppActions, uuid: string) =>
       data.uuid = uuid; // necessary because the API lacks this ID in the response
       return data;
     })
-    .then(data => Promise.all([actions.upsertInvitation(data, data.organization.uuid)]))
+    .then(data =>
+      Promise.all([actions.upsertInvitation(data, data.organization.uuid)])
+    )
     .catch(error => {
       console.error('API Error fetchInvitation', error, error.code);
     });
 
 export const fetchInvitationsForUser = (actions: AppActions, uuid: string) =>
   cfetch(
-    `${process.env.REACT_APP_SQUARELET_API_URL}/users/${uuid}/invitations`,
+    `${process.env.REACT_APP_SQUARELET_API_URL}/users/${uuid}/invitations/?expand=organization`,
     GET
   )
     .then(checkAuth(actions))

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -21,8 +21,12 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
+
       for (let invitation of action.invitations) {
-        incomingObject.invitations[invitation.organization.uuid] = invitation;
+        if (!incomingObject.invitations[invitation.organization.uuid]) {
+          incomingObject.invitations[invitation.organization.uuid] = [];
+        }
+        incomingObject.invitations[invitation.organization.uuid].push(invitation);
       }
       return Object.assign({}, state, incomingObject);
     }
@@ -31,7 +35,12 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      incomingObject.invitations[action.organization_id] = action.invitation;
+
+      if (!incomingObject.invitations[action.organization_id]) {
+        incomingObject.invitations[action.organization_id] = [];
+      }
+
+      incomingObject.invitations[action.organization_id].push(action.invitation);
       return Object.assign({}, state, incomingObject);
     }
     case DELETE_INVITATION: {

--- a/src/store/invitations/reducers.ts
+++ b/src/store/invitations/reducers.ts
@@ -31,7 +31,7 @@ export function invitationReducers(
         invitations: Object.assign({}, state.invitations),
         hydrated: true
       };
-      incomingObject.invitations[action.invitation.uuid] = action.invitation;
+      incomingObject.invitations[action.organization_id] = action.invitation;
       return Object.assign({}, state, incomingObject);
     }
     case DELETE_INVITATION: {

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -18,7 +18,7 @@ export interface Invitation {
 }
 
 export interface InvitationState {
-  invitations: { [id: string]: Invitation };
+  invitations: { [id: string]: Invitation[] };
   hydrated: boolean;
 }
 

--- a/src/store/invitations/types.ts
+++ b/src/store/invitations/types.ts
@@ -18,13 +18,14 @@ export interface Invitation {
 }
 
 export interface InvitationState {
-  invitations: { [id: number]: Invitation };
+  invitations: { [id: string]: Invitation };
   hydrated: boolean;
 }
 
 export interface UpsertInvitationAction {
   type: typeof UPSERT_INVITATION;
   invitation: Invitation;
+  organization_id: string;
 }
 
 export interface UpsertInvitationsAction {


### PR DESCRIPTION
This PR changes the invitation store to group invites by their organization uuid instead of using the invitation unique ID (issue #54). This required a little bit of work on the action/reducer side - because the API unfortunately doesn't return the org ID in the invitation data.

It also includes an update to the OrganizationsList page, using the new User Invitations endpoint of the squarelet API (PR https://github.com/MuckRock/squarelet/pull/43, use branch feature/user-invitations-endpoint until it's merged). In my scenario, where I've requested to join the Philly Inquirer in the past, have not requested the SMH, and I am a member of the rest of the orgs:

<img width="1381" alt="Screen Shot 2020-04-01 at 11 18 17 am" src="https://user-images.githubusercontent.com/3397/78087027-679c9a00-740b-11ea-87a2-c03f51b2a5d2.png">
