### PR TITLE
Omit managing member requests, plans and subs on create org page

### DIFF
--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -2,6 +2,8 @@
 // the 'create' component and the 'edit' component.
 
 import React, { useState, SyntheticEvent } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import { Organization } from '../store/organizations/types';
 import Field from '../common/Field';
 import { Plan, PlanState } from '../store/plans/types';
@@ -23,6 +25,52 @@ interface OrganizationFormProps {
   subscriptions: SubscriptionState;
   users: UsersState;
 }
+
+const ExistingOrganizationFields: React.FC<OrganizationFormProps> = (
+  props: OrganizationFormProps
+) => {
+  let organization = props.organization;
+
+  let location = useLocation();
+
+  if (location.pathname === '/organizations/create') {
+    return <div></div>;
+  }
+
+  console.log(location);
+  return (
+    <div>
+      <div className="container">
+        <h1 className="title">Membership Requests</h1>
+        <InvitationsList
+          organization={organization}
+          users={props.users}
+          invitations={props.invitations}
+          actions={props.actions}
+        />
+      </div>
+      <hr />
+      <div className="container">
+        <h1 className="title">Subscriptions</h1>
+        <SubscriptionsList
+          organization={organization}
+          subscriptions={props.subscriptions}
+          actions={props.actions}
+        />
+      </div>
+      <hr />
+      <div className="container">
+        <h1 className="title">Available Plans</h1>
+        <PlansList
+          organization={organization}
+          plans={props.plans}
+          users={props.users}
+          actions={props.actions}
+        />
+      </div>
+    </div>
+  );
+};
 
 const OrganizationForm: React.FC<OrganizationFormProps> = (
   props: OrganizationFormProps
@@ -93,34 +141,17 @@ const OrganizationForm: React.FC<OrganizationFormProps> = (
         </label>
       </Field>
       <hr />
-      <div className="container">
-        <h1 className="title">Membership Requests</h1>
-        <InvitationsList
-          organization={organization}
-          users={props.users}
-          invitations={props.invitations}
-          actions={props.actions}
-        />
-      </div>
-      <hr />
-      <div className="container">
-        <h1 className="title">Subscriptions</h1>
-        <SubscriptionsList
-          organization={organization}
-          subscriptions={props.subscriptions}
-          actions={props.actions}
-        />
-      </div>
-      <hr />
-      <div className="container">
-        <h1 className="title">Available Plans</h1>
-        <PlansList
-          organization={organization}
-          plans={props.plans}
-          users={props.users}
-          actions={props.actions}
-        />
-      </div>
+
+      <ExistingOrganizationFields
+        actions={props.actions}
+        errors={errors}
+        invitations={props.invitations}
+        onSubmit={props.onSubmit}
+        organization={organization}
+        plans={props.plans}
+        subscriptions={props.subscriptions}
+        users={props.users}
+      />
       <br />
       <button type="submit" className="button is-link">
         Save


### PR DESCRIPTION
This PR removes the following 3 sections from the organization form when creating a new org:

* managing member requests
* subscribing to plans
* viewing/managing existing subscriptions

Closes issue #68 