### PR TITLE
Wire up archieml copy to components

### DIFF
--- a/src/archie.json
+++ b/src/archie.json
@@ -1,1 +1,1 @@
-{"Title":"PressPass"}
+{"title":"PressPass","entitlements":{"title":"Grants","description":"Services you’re able to access based on the plans you’re subscribed to."},"organizations":{"title":"Organizations","description":"Groups available on PressPass."}}

--- a/src/entitlements/EntitlementsList.tsx
+++ b/src/entitlements/EntitlementsList.tsx
@@ -4,9 +4,11 @@ import { ensureEntitlements } from '../store/entitlements/api';
 import EntitlementCard from './EntitlementCard';
 import { EntitlementState, Entitlement } from '../store/entitlements/types';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
+import { ArchieState } from '../store/archie/types';
 
 interface EntitlementsListProps {
   actions: AppActions;
+  archie: ArchieState;
   entitlements: EntitlementState;
 }
 
@@ -23,7 +25,10 @@ const EntitlementsList: React.FC<EntitlementsListProps> = (
 
   return (
     <div className="entitlements">
-      <h1 className="title is-size-1">Entitlements</h1>
+      <section className="section">
+        <h1 className="title is-size-1">{props.archie.copy.entitlements.title}</h1>
+        <p>{props.archie.copy.entitlements.description}</p>
+      </section>
       <div className="columns is-multiline">
         {Object.values(props.entitlements.entitlements).map(
           (entitlement: Entitlement) => (

--- a/src/entitlements/routing.tsx
+++ b/src/entitlements/routing.tsx
@@ -8,7 +8,7 @@ export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
   const routes = [
     <ProtectedRoute exact path="/entitlements" {...authProps}>
-      <EntitlementsList actions={props.actions} entitlements={props.entitlements} />
+      <EntitlementsList actions={props.actions} archie={props.archie} entitlements={props.entitlements} />
     </ProtectedRoute>
   ];
   return routes;

--- a/src/organization/OrganizationsList.tsx
+++ b/src/organization/OrganizationsList.tsx
@@ -6,6 +6,7 @@ import { ensureOrganizations } from '../store/organizations/api';
 import OrganizationCard from './OrganizationCard';
 import LoadingPlaceholder from '../common/LoadingPlaceholder';
 import Field from '../common/Field';
+import { ArchieState } from '../store/archie/types';
 import { InvitationState } from '../store/invitations/types';
 import { MembershipState } from '../store/memberships/types';
 import { OrganizationState, Organization } from '../store/organizations/types';
@@ -13,6 +14,7 @@ import { UsersState } from '../store/users/types';
 
 interface OrganizationsListProps {
   actions: AppActions;
+  archie: ArchieState;
   invitations: InvitationState;
   memberships: MembershipState;
   organizations: OrganizationState;
@@ -66,7 +68,10 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = (
   };
   return (
     <div className="organizations">
-      <h1 className="title is-size-1">Organizations</h1>
+      <section className="section">
+        <h1 className="title is-size-1">{props.archie.copy.organizations.title}</h1>
+        <p>{props.archie.copy.entitlements.description}</p>
+      </section>
       <form>
         <Field label="Search">
           <input

--- a/src/organization/routing.tsx
+++ b/src/organization/routing.tsx
@@ -16,6 +16,7 @@ export const getRoutes = (props: AppProps) => {
     <ProtectedRoute exact path="/organizations" {...authProps}>
       <OrganizationsList
         actions={props.actions}
+        archie={props.archie}
         invitations={props.invitations}
         memberships={props.memberships}
         organizations={props.organizations}


### PR DESCRIPTION
This is just a quick PR that wires up archieml-supplied copy from the store into components. It is setting a title and description for the two main PressPass list pages: entitlements (which I decided to call 'Grants') and organizations.