### PR TITLE
Homepage for unauthenticated users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { fetchSelfUser } from './store/users/api';
 import Navbar from './common/Navbar';
 import { ProtectedRoute } from './common/routing';
 import NotFound from './common/NotFound';
+import HomePage from './common/HomePage';
 
 // Routes
 import { getRoutes as authRoutes } from './auth/routing';
@@ -42,8 +43,10 @@ import './App.css';
 
 const App = (props: AppProps) => {
   useEffect(() => {
-    forceCheckAuth(props.actions);
-    fetchSelfUser(props.actions);
+    if (document.location.pathname != "/" && document.location.pathname != "/index.html") {
+      forceCheckAuth(props.actions);
+      fetchSelfUser(props.actions);
+    }
   }, [props.actions]); // only run once
 
   const authProps = AuthProps(props);
@@ -59,18 +62,18 @@ const App = (props: AppProps) => {
         <section className="section">
           <div className="container">
             <Switch>
-              <ProtectedRoute exact path="/" {...authProps}>
-                <Redirect to="/entitlements" />
-              </ProtectedRoute>
-              <ProtectedRoute exact path="/index.html" {...authProps}>
-                <Redirect to="/entitlements" />
-              </ProtectedRoute>
               {authRoutes(props).map(route => route)}
               {clientsRoutes(props).map(route => route)}
               {accountRoutes(props).map(route => route)}
               {entitlementsRoutes(props).map(route => route)}
               {membershipsRoutes(props).map(route => route)}
               {organizationsRoutes(props).map(route => route)}
+              <Route path="/">
+                <HomePage/>
+              </Route>
+              <Route path="/index.html">
+                <HomePage/>
+              </Route>
               <Route path="*">
                 <NotFound />
               </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,6 @@ import { fetchSelfUser } from './store/users/api';
 
 // Common
 import Navbar from './common/Navbar';
-import { ProtectedRoute } from './common/routing';
 import NotFound from './common/NotFound';
 import HomePage from './common/HomePage';
 

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -86,7 +86,7 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
   }
 
   // necessary as just linking to /register results in location missing the original return url
-  let returnUrl = '/';
+  let returnUrl = '/entitlements';
   if (location.state) {
     returnUrl = location.state.return;
   }
@@ -94,7 +94,7 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
     pathname: '/register',
     state: { return: returnUrl }
   };
-  const redirectUrl = location.state ? location.state.return : '/';
+  const redirectUrl = location.state ? location.state.return : '/entitlements';
 
   return props.auth.loggedIn ? (
     <div className="notification is-success">

--- a/src/common/HomePage.tsx
+++ b/src/common/HomePage.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const HomePage: React.FC = () => {
+  return (
+    <section className="hero is-medium is-warning is-rounded is-bold">
+      <div className="hero-body">
+        <div className="container">
+          <p className="heading is-size-6">PressPass</p>
+          <h1 className="title is-size-1">This is the homepage that unauthenticated visitors to our site will see at http://presspass.com.</h1>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HomePage;


### PR DESCRIPTION
This PR adds a homepage - or rather, a placeholder homepage - for visitors who land on presspass.com. Or whatever our domain will be when launched.

* new `HomePage` component lives in `common/`
* `forceCheckAuth` and `fetchSelfUser` not run on `/` or `/index.html`
  * this prevents the console errors & 'login to continue' notification from showing up
* default redirect after login still `/entitlements`, otherwise your original destination