### PR TITLE
Include profile avatar in nav if set

### DIFF
--- a/src/common/Navbar.tsx
+++ b/src/common/Navbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ProfileAvatar from '../account/ProfileAvatar';
 import { Link, RouteProps } from 'react-router-dom';
 import { AppActions } from '../store';
 import { User } from '../store/users/types';
@@ -12,12 +13,46 @@ export interface NavbarProps extends RouteProps {
   archie: ArchieState;
 }
 
+interface NavbarProfileHeaderProps {
+  archie: ArchieState;
+  user: User | null;
+}
+
+const NavbarProfileHeader = (props: NavbarProfileHeaderProps) => {
+  let avatar;
+  if (props.user === null) {
+    return (
+      <a href="/" className="navbar-link">
+        {props.archie.copy.nav.account}
+      </a>
+    )
+  }
+
+  if (props.user.avatar === null) {
+    avatar = "/logo.svg"; // default to presspass logo for now
+  } else {
+    avatar = props.user.avatar;
+  }
+  return (
+      <a className="navbar-link" href="/">
+        <div className="level">
+          <div className="level-left">
+            <figure className="image is-32x32 has-margin-right-5">
+              <img alt="profile" src={avatar} />
+            </figure>
+          </div>
+          <div className="level-left">
+            {props.user.username}
+          </div>
+        </div>
+      </a>
+  )
+}
+
 const Navbar = (props: NavbarProps) => {
   const navRight = props.isAuthenticated ? (
     <div className="navbar-item has-dropdown is-hoverable">
-      <a className="navbar-link" href="/">
-        {props.user === null ? props.archie.copy.nav.account : props.user.name}
-      </a>
+      <NavbarProfileHeader archie={props.archie} user={props.user} />
 
       <div className="navbar-dropdown">
         <Link className="navbar-item" to="/profile">

--- a/src/index.scss
+++ b/src/index.scss
@@ -95,6 +95,9 @@ hr {
   }
 }
 
+.has-margin-right-5 {
+  margin-right: 5px;
+}
 .has-padding-top-50 {
   padding-top: 50px;
 }


### PR DESCRIPTION
Per issue #90, this PR adds the profile avatar to the navbar. I set it to the presspass logo if it's not set.

As an aside, I'm not sure the API avatar uploading is working right on the user - it seems to work on the organization. I'll open a separate issue.