### PR TITLE
Upload & display user profile avatar

### DIFF
--- a/src/account/ManageProfile.tsx
+++ b/src/account/ManageProfile.tsx
@@ -26,10 +26,11 @@ export const HydratedManageProfile: React.FC<ManageProfilePageProps> = (
   props: ManageProfilePageProps
 ) => {
   let [errors, setErrors] = useState<any>({});
+  let [saved, setSaved] = useState(false);
   let [name, setName] = useState(props.users.self!.name);
   let [email, setEmail] = useState(props.users.self!.email);
   let [username, setUsername] = useState(props.users.self!.username);
-  let [saved, setSaved] = useState(false);
+  let [avatar, setAvatar] = useState<File | undefined>(undefined);
 
   function handleProfileUpdateSubmit(event: SyntheticEvent) {
     event.preventDefault();
@@ -37,7 +38,8 @@ export const HydratedManageProfile: React.FC<ManageProfilePageProps> = (
       ...props.users.self!,
       name,
       username,
-      email
+      email,
+      avatar
     };
     updateSelfUser(user, props.actions).then(status => {
       if (status.ok) {
@@ -89,6 +91,22 @@ export const HydratedManageProfile: React.FC<ManageProfilePageProps> = (
             className={errors.email ? 'input is-danger' : 'input'}
             value={email}
             onChange={event => setEmail(event.target.value)}
+          />
+        </Field>
+        <Field
+          label="Avatar"
+          errors={errors.avatar}
+          help="If you do not upload a file, the current photo will be kept."
+        >
+          <input
+            className={errors.avatar ? 'input is-danger' : 'input'}
+            type="file"
+            placeholder="Your photo..."
+            onChange={event =>
+              setAvatar(
+                event.target.files === null ? undefined : event.target.files[0]
+              )
+            }
           />
         </Field>
         <button className="button is-link" type="submit">

--- a/src/account/ProfileAvatar.tsx
+++ b/src/account/ProfileAvatar.tsx
@@ -10,7 +10,7 @@ const ProfileAvatar: React.FC<ProfileAvatarProps> = (
   if (props.avatar) {
     return (
       <div className="media-left">
-        <figure className="image is-64x64">
+        <figure className="image is-128x128">
           <img alt="profile" src={props.avatar} />
         </figure>
       </div>

--- a/src/account/ProfileAvatar.tsx
+++ b/src/account/ProfileAvatar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface ProfileAvatarProps {
-  avatar: string;
+  avatar?: any;
 }
 
 const ProfileAvatar: React.FC<ProfileAvatarProps> = (

--- a/src/store/users/api.ts
+++ b/src/store/users/api.ts
@@ -14,7 +14,8 @@ const serializeUser = (user: User) => ({
   name: user.name,
   username: user.username,
   use_autologin: user.use_autologin,
-  uuid: user.uuid
+  uuid: user.uuid,
+  avatar: user.avatar
 });
 
 export const fetchSelfUser = (actions: AppActions) =>

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -5,7 +5,7 @@ export interface User {
   name: string;
   email: string;
   email_failed: boolean;
-  avatar: string;
+  avatar?: string | File;
   username: string;
   created_at: Date;
   updated_at: Date;


### PR DESCRIPTION
(issue #96)

No problem with the API at all - the profile update form just lacked an avatar field *phew* :D 

I can now upload/change my profile photo and see it reflected immediately in the navbar. I also bumped the size of the avatar photo on the profile page.