### PR TITLE
Feature/no joining individual orgs

### DIFF
--- a/src/membership/MembershipCard.tsx
+++ b/src/membership/MembershipCard.tsx
@@ -34,7 +34,7 @@ interface InviteButtonProps {
 const InviteButton: React.FC<InviteButtonProps> = (
   props: InviteButtonProps
 ) => {
-  if (!props.membership.admin) {
+  if (!props.membership.admin || props.membership.organization.individual) {
     return null;
   }
   return (

--- a/src/organization/ManageOrganizationPage.tsx
+++ b/src/organization/ManageOrganizationPage.tsx
@@ -92,10 +92,6 @@ export const ManageOrganizationPage = (props: ManageOrganizationPageProps) => {
           subscriptions={props.subscriptions}
           users={props.users}
         />
-        <p>
-          Manage organization page (id {organization.uuid}) (
-          <Link to=".">view</Link>)
-        </p>
       </section>
     );
   }

--- a/src/organization/OrganizationCard.tsx
+++ b/src/organization/OrganizationCard.tsx
@@ -64,6 +64,10 @@ const OrganizationCardNav: React.FC<OrganizationCardProps> = (
       );
     }
   }
+  // don't show join buttons for individual organizations
+  if (props.organization.individual) {
+    return null;
+  }
   let userRequestedMembership =
     props.organization.uuid in props.invitations.invitations &&
     props.invitations.invitations[props.organization.uuid].find(

--- a/src/organization/OrganizationForm.tsx
+++ b/src/organization/OrganizationForm.tsx
@@ -37,8 +37,7 @@ const ExistingOrganizationFields: React.FC<OrganizationFormProps> = (
     return <div></div>;
   }
 
-  console.log(location);
-  return (
+  var membershipRequests = (
     <div>
       <div className="container">
         <h1 className="title">Membership Requests</h1>
@@ -50,6 +49,12 @@ const ExistingOrganizationFields: React.FC<OrganizationFormProps> = (
         />
       </div>
       <hr />
+    </div>
+  )
+
+  return (
+    <div>
+      {organization.individual ? '' : membershipRequests}
       <div className="container">
         <h1 className="title">Subscriptions</h1>
         <SubscriptionsList

--- a/src/organization/OrganizationPage.tsx
+++ b/src/organization/OrganizationPage.tsx
@@ -37,10 +37,6 @@ export const OrganizationPage = (props: OrganizationPageProps) => {
         memberships={props.memberships}
         organization={organization}
       />
-      <p>
-        Organization page (id {organization.uuid}) (
-        <Link to={`./${organization.uuid}/manage`}>{props.archie.copy.buttons.manage}</Link>)
-      </p>
     </section>
   );
 };


### PR DESCRIPTION
Issue #104 

This removes "request to join" and "invite" buttons from individual organization displays. Along the way, I discovered some buggy logic around the display of 'admin' vs 'member' tags plus functionality and cleaned that up as well.