### PR TITLE
Setup oauth redirect route for logging in via third-party button

### DIFF
--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -5,6 +5,7 @@ import { Redirect, useLocation } from 'react-router';
 import { cfetch } from '../utils';
 import Field from '../common/Field';
 import { Link } from 'react-router-dom';
+import { fetchSelfUser } from "../store/users/api";
 
 type LoginFormResponse = {
   non_field_errors: string[];
@@ -74,6 +75,7 @@ const LoginPage: React.FC<LoginProps> = (props: LoginProps) => {
       setResponse(response);
       if (response.responseCode === 200) {
         props.actions.login();
+        fetchSelfUser(props.actions);
       }
     });
   };

--- a/src/auth/routing.tsx
+++ b/src/auth/routing.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route } from "react-router";
+import { Route, useLocation } from "react-router";
 import LoginPage from "./LoginPage";
 import LogoutPage from "./LogoutPage";
 import RegisterPage from "./RegisterPage";
@@ -9,7 +9,9 @@ import {
 } from "./PasswordResetPages";
 import { AppProps } from "../store";
 import { AuthProps } from "../store/auth/types";
+import { ProtectedRoute } from "../common/routing";
 import Container from "../common/Container";
+import queryString from "query-string";
 
 export const getRoutes = (props: AppProps) => {
   const authProps = AuthProps(props);
@@ -34,6 +36,15 @@ export const getRoutes = (props: AppProps) => {
         <PasswordResetPage actions={props.actions} />
       </Container>
     </Route>,
+    <ProtectedRoute exact path="/oauth-login" component={() => {
+      let location = useLocation();
+      let queryValues = queryString.parse(window.location.search);
+      // need both checks because isAuthenticated is true by default
+      if (authProps.isAuthenticated && props.users.self) {
+        window.location.replace(queryValues.loginURL);
+      }
+      return null;
+    }} {...authProps} ></ProtectedRoute>,
     <Route
       exact
       path="/resetpassword/submit/:uid/:token"

--- a/src/common/routing.tsx
+++ b/src/common/routing.tsx
@@ -12,7 +12,7 @@ export const ProtectedRoute = (props: ProtectedRouteProps) => {
   if (!props.isAuthenticated) {
     let returnPath =
       props.returnPath === undefined
-        ? props.location!.pathname
+        ? `${props.location!.pathname}${props.location!.search}`
         : props.returnPath;
     return (
       <Route>


### PR DESCRIPTION
This is the solution to #115. We will direct third-party clients to implement a button that sends to `presspass.it/oauth-login/?loginURL=http://theirapp.com/login`. This route checks if you're logged in, sends you to the PressPass login form if not, and then redirects you back to the login route for the third-party app.

The biggest change I had to make here is making sure that we fetch your user info immediately after logging in. That's how I check whether we should redirect you or not.